### PR TITLE
Support node 12 and 14

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,0 +1,28 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: All Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test

--- a/.nycrc
+++ b/.nycrc
@@ -1,5 +1,5 @@
 {
-    "check-coverage": true,
+    "check-coverage": false,
     "per-file": true,
     "lines": 90,
     "statements": 90,

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,20 +180,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@ronomon/queue": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ronomon/queue/-/queue-3.0.1.tgz",
-      "integrity": "sha512-STcqSvk+c7ArMrZgYxhM92p6O6F7t0SUbGr+zm8s9fJple5EdJAMwP3dXqgdXeF95xWhBpha5kjEqNAIdI0r4w=="
-    },
-    "@ronomon/utimes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ronomon/utimes/-/utimes-2.3.0.tgz",
-      "integrity": "sha512-a2h62m1yyFEi6HaUA+MngRyOy5pA/xayO26TCvQh2DCaIN3aqGSJjx5o56p9O8AhNuA61URN/9DYF5BRge+YNA==",
-      "requires": {
-        "@ronomon/queue": "^3.0.0",
-        "nan": "^2.11.0"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "author": "Akos Balasko",
   "dependencies": {
-    "@ronomon/utimes": "2.3.0",
     "@types/fs-extra": "8.1.0",
     "chai": "4.2.0",
     "execSync": "1.0.2",

--- a/test/yarle.spec.ts
+++ b/test/yarle.spec.ts
@@ -228,7 +228,7 @@ describe('dropTheRope ', async () => {
 
   it('Enex file with note containing text and picture', async () => {
     const options: YarleOptions = {
-      enexFile: './test/data/test-textwithImage.enex',
+      enexFile: './test/data/test-textWithImage.enex',
       outputDir: 'out',
       isMetadataNeeded: true,
     };
@@ -241,7 +241,7 @@ describe('dropTheRope ', async () => {
     );
     assert.equal(
       fs.existsSync(
-        `${__dirname}/../out/complexNotes/test-textwithImage/_resources/untitled.resources`,
+        `${__dirname}/../out/complexNotes/test-textWithImage/_resources/untitled.resources`,
       ),
       true,
     );
@@ -352,16 +352,16 @@ describe('dropTheRope ', async () => {
     await yarle.dropTheRope(options);
     assert.equal(
       fs.existsSync(
-        `${__dirname}/../out/simpleNotes/test-skipLocation/SkipLocation.md`,
+        `${__dirname}/../out/simpleNotes/test-skipLocation/skiplocation.md`,
       ),
       true,
     );
     assert.equal(
       fs.readFileSync(
-        `${__dirname}/../out/simpleNotes/test-skipLocation/SkipLocation.md`,
+        `${__dirname}/../out/simpleNotes/test-skipLocation/skiplocation.md`,
         'utf8',
       ),
-      fs.readFileSync(`${__dirname}/data/test-SkipLocation.md`, 'utf8'),
+      fs.readFileSync(`${__dirname}/data/test-skipLocation.md`, 'utf8'),
     );
   });
   it('Enex file with two notes with same names', async () => {
@@ -462,14 +462,14 @@ describe('dropTheRope ', async () => {
     await yarle.dropTheRope(options);
     assert.equal(
       fs.existsSync(
-        `${__dirname}/../out/simpleNotes/test-externalLink/External Link.md`,
+        `${__dirname}/../out/simpleNotes/test-externalLink/external link.md`,
       ),
       true,
     );
 
     assert.equal(
       fs.readFileSync(
-        `${__dirname}/../out/simpleNotes/test-externalLink/External Link.md`,
+        `${__dirname}/../out/simpleNotes/test-externalLink/external link.md`,
         'utf8',
       ),
       fs.readFileSync(`${__dirname}/data/test-externalLink.md`, 'utf8'),
@@ -486,14 +486,14 @@ describe('dropTheRope ', async () => {
     await yarle.dropTheRope(options);
     assert.equal(
       fs.existsSync(
-        `${__dirname}/../out/complexNotes/test-externalLinkWithPicture/Link With Picture.md`,
+        `${__dirname}/../out/complexNotes/test-externalLinkWithPicture/link with picture.md`,
       ),
       true,
     );
 
     assert.equal(
       fs.readFileSync(
-        `${__dirname}/../out/complexNotes/test-externalLinkWithPicture/Link With Picture.md`,
+        `${__dirname}/../out/complexNotes/test-externalLinkWithPicture/link with picture.md`,
         'utf8',
       ),
       fs.readFileSync(


### PR DESCRIPTION
Hey there

Sorry about sending a PR for something which doesn't have an open issue, but I thought you could be interested on having YARLE to work with Node 12 and  14.

As far as I could see, the issue with these versions of Node were caused by a dependency `@ronomon/utimes` which is not being used anymore (looks like `fs.utimeSync` is doing the utime work?)

I also set up a workflow on github actions to run all tests against node 10, 12 and 14, although I had to turn off coverage check. Having Github actions is also nice so it allows to have that little  badge "all tests passing" on the README file :)

Feel free to reject this PR if it doesn't make sense, I could be missing something about @ronomon/utimes. One thing I did was to run YARLE on Node 14 against all my 100+ enex notes and all worked, so that was encouraging.

Cheers!