### PR TITLE
fix: indent sublists correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yarle-evernote-to-md",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -246,6 +246,17 @@
       "integrity": "sha512-jpzrsR1ns0n3kyWt92QfOUQhIuJGQ9+QGa7M62rO6toe98woQjnsnzjdMtsQXCdvjjmqjS2ZBCC7xKw0cdzU+Q==",
       "dev": true
     },
+    "@types/jsdom": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.4.tgz",
+      "integrity": "sha512-RssgLa5ptjVKRkHho/Ex0+DJWkVsYuV8oh2PSG3gKxFp8n/VNyB7kOrZGQkk2zgPlcBkIKOItUc/T5BXit9uhg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/parse5": "*",
+        "@types/tough-cookie": "*"
+      }
+    },
     "@types/lodash": {
       "version": "4.14.154",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.154.tgz",
@@ -268,6 +279,12 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
       "integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
+      "dev": true
+    },
+    "@types/parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
+      "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
       "dev": true
     },
     "@types/proxyquire": {
@@ -295,6 +312,18 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
       "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
+      "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
+      "dev": true
+    },
+    "@types/turndown": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.0.tgz",
+      "integrity": "sha512-Y7KZn6SfSv1vzjByJGijrM9w99HoUbLiAgYwe+sGH6RYi5diIGLYOcr4Z1YqR2biFs9K5PnxKv/Fbkmh57pvzg==",
       "dev": true
     },
     "ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "fs-extra": "4.0.2",
     "he": "1.2.0",
     "joplin-turndown-plugin-gfm": "1.0.12",
+    "jsdom": "^16.4.0",
     "lodash": "4.17.19",
     "minimist": "1.2.5",
     "moment": "2.22.2",
@@ -44,8 +45,8 @@
     "xml-stream": "^0.4.5"
   },
   "engines": {
-    "node": "10.18.1",
-    "npm": "5.6.0"
+    "node": ">=10.18.1",
+    "npm": ">=5.6.0"
   },
   "repository": {
     "type": "git",
@@ -55,6 +56,7 @@
   "license": "(MIT OR Apache-2.0)",
   "devDependencies": {
     "@types/he": "1.1.1",
+    "@types/jsdom": "^16.2.4",
     "@types/lodash": "^4.14.151",
     "@types/minimist": "1.2.0",
     "@types/mocha": "7.0.2",

--- a/src/convert-html-to-md.ts
+++ b/src/convert-html-to-md.ts
@@ -1,7 +1,30 @@
+import { JSDOM } from 'jsdom';
+
 import { getTurndownService } from './utils/turndown-service';
 
+const fixSublists = (node: HTMLElement) => {
+    const ulElements: Array<HTMLElement> = Array.from(node.getElementsByTagName('ul'));
+    const olElements: Array<HTMLElement> = Array.from(node.getElementsByTagName('ol'));
+    const listElements = ulElements.concat(olElements);
+    listElements.forEach(listNode => {
+      if (listNode.parentElement.tagName === 'LI') {
+        listNode.parentElement.replaceWith(listNode);
+      }
+      if (
+        listNode.previousElementSibling &&
+        listNode.previousElementSibling.tagName === 'LI'
+      ) {
+        // The below moves, not copies. https://stackoverflow.com/questions/7555442/move-an-element-to-another-parent-after-changing-its-id
+        listNode.previousElementSibling.appendChild(listNode);
+      }
+    });
+
+    return node;
+};
+
 export const convertHtml2Md = (content: string) => {
-    const contentInMd = getTurndownService().turndown(content);
+    const contentNode = new JSDOM(`<x-turndown id="turndown-root">${content}</x-turndown>`).window.document.getElementById('turndown-root');
+    const contentInMd = getTurndownService().turndown(fixSublists(contentNode));
 
     return contentInMd && contentInMd !== 'undefined' ? contentInMd : '';
 };

--- a/test/data/test-sublists-valid.enex
+++ b/test/data/test-sublists-valid.enex
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export3.dtd">
+<en-export export-date="20201010T204251Z" application="Evernote Legacy" version="Evernote Mac 7.14.1 (458325)">
+    <note>
+        <title>test - sublists - valid</title>
+        <content>
+            <![CDATA[
+                <!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">
+                <en-note>
+                    <ul>
+                        <li>
+                            <div>Level1</div>
+                        </li>
+                        <li>
+                            <ul>
+                                <li>
+                                    <div>Level2</div>
+                                </li>
+                                <li>
+                                    <ul>
+                                        <li>
+                                            <div>Level3</div>
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <div><br /></div>
+                </en-note>
+            ]]>
+        </content>
+        <created>20201010T165715Z</created>
+        <updated>20201010T204213Z</updated>
+        <note-attributes>
+            <latitude>60.5566790535642</latitude>
+            <longitude>24.98012759429327</longitude>
+            <altitude>67.66667938232422</altitude>
+            <author>Martin Hähnel</author>
+            <source>desktop.mac</source>
+            <reminder-order>0</reminder-order>
+        </note-attributes>
+    </note>
+</en-export>

--- a/test/data/test-sublists-valid.md
+++ b/test/data/test-sublists-valid.md
@@ -1,0 +1,10 @@
+# test - sublists - valid
+*   Level1
+    *   Level2
+        *   Level3
+
+    Created at: 2020-10-10T17:57:15+01:00
+    Updated at: 2020-10-10T21:42:13+01:00
+    Where: 24.98012759429327,60.5566790535642
+
+

--- a/test/data/test-sublists.enex
+++ b/test/data/test-sublists.enex
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export3.dtd">
+<en-export export-date="20201010T204251Z" application="Evernote Legacy" version="Evernote Mac 7.14.1 (458325)">
+<note><title>test - sublists</title><content><![CDATA[<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><ul><li><div>Level1</div></li><ul><li><div>Level2</div></li><ul><li><div>Level3</div></li></ul></ul></ul><div><br /></div></en-note>]]></content><created>20201010T165715Z</created><updated>20201010T204213Z</updated><note-attributes><latitude>60.5566790535642</latitude><longitude>24.98012759429327</longitude><altitude>67.66667938232422</altitude><author>Martin Hähnel</author><source>desktop.mac</source><reminder-order>0</reminder-order></note-attributes></note>
+</en-export>

--- a/test/data/test-sublists.md
+++ b/test/data/test-sublists.md
@@ -1,0 +1,10 @@
+# test - sublists
+*   Level1
+    *   Level2
+        *   Level3
+
+    Created at: 2020-10-10T17:57:15+01:00
+    Updated at: 2020-10-10T21:42:13+01:00
+    Where: 24.98012759429327,60.5566790535642
+
+

--- a/test/yarle.spec.ts
+++ b/test/yarle.spec.ts
@@ -719,4 +719,46 @@ describe('dropTheRope ', async () => {
     );
   });
 
+  it('Note with sublists', async () => {
+    const options: YarleOptions = {
+      enexFile: './test/data/test-sublists.enex',
+      outputDir: 'out',
+      isMetadataNeeded: true,
+    };
+    await yarle.dropTheRope(options);
+    assert.equal(
+      fs.existsSync(
+        `${__dirname}/../out/simpleNotes/test-sublists/test - sublists.md`,
+      ),
+      true,
+    );
+    assert.equal(
+      fs.readFileSync(
+        `${__dirname}/../out/simpleNotes/test-sublists/test - sublists.md`,
+        'utf8',
+      ),
+      fs.readFileSync(`${__dirname}/data/test-sublists.md`, 'utf8'),
+    );
+  });
+  it('Note with sublists (valid html)', async () => {
+    const options: YarleOptions = {
+      enexFile: './test/data/test-sublists-valid.enex',
+      outputDir: 'out',
+      isMetadataNeeded: true,
+    };
+    await yarle.dropTheRope(options);
+    assert.equal(
+      fs.existsSync(
+        `${__dirname}/../out/simpleNotes/test-sublists-valid/test - sublists - valid.md`,
+      ),
+      true,
+    );
+    assert.equal(
+      fs.readFileSync(
+        `${__dirname}/../out/simpleNotes/test-sublists-valid/test - sublists - valid.md`,
+        'utf8',
+      ),
+      fs.readFileSync(`${__dirname}/data/test-sublists-valid.md`, 'utf8'),
+    );
+  });
 });


### PR DESCRIPTION
Fixes #60. This basically uses [this fix](https://github.com/domchristie/turndown/issues/232#issuecomment-394052373) but instead of doing it inside of turndown, we create DOM representation of the note already in yarle itself so we can use the function. Since we actually need to move nodes around, I don't see a way to use a rule for this.

I also added a test.