### PR TITLE
Fix: Negative Failed Count

### DIFF
--- a/src/convert-html-to-md.ts
+++ b/src/convert-html-to-md.ts
@@ -34,8 +34,7 @@ const fixSublists = (node: HTMLElement) => {
 
 export const convertHtml2Md = (content: string) => {
     const contentNode = new JSDOM(`<x-turndown id="turndown-root">${content}</x-turndown>`).window.document.getElementById('turndown-root');
-    
-    let contentInMd = getTurndownService().turndown(fixSublists(contentNode));
-    
+    const contentInMd = getTurndownService().turndown(fixSublists(contentNode));
+
     return contentInMd && contentInMd !== 'undefined' ? contentInMd : '';
 };

--- a/src/process-node.ts
+++ b/src/process-node.ts
@@ -7,7 +7,7 @@ import { convertHtml2Md } from './convert-html-to-md';
 
 export const processNode = (note: any): void => {
     const title = getTitle(note);
-  
+
     console.log(`Converting note ${title}...`);
     try {
       let data = '';

--- a/src/yarle.ts
+++ b/src/yarle.ts
@@ -23,7 +23,6 @@ export const parseStream = async (options: YarleOptions): Promise<void> => {
   const xml = new XmlStream(stream);
   let noteNumber = 0;
   let failed = 0;
-  let totalNotes = 0;
 
   return new Promise((resolve, reject) => {
     const logAndReject = (error: Error) => {
@@ -32,12 +31,9 @@ export const parseStream = async (options: YarleOptions): Promise<void> => {
 
       return reject();
     };
-  
+
     xml.collect('tag');
     xml.collect('resource');
-    xml.on('startElement: en-export', (enExport: any) => {
-      totalNotes = Array.isArray(enExport.note) ? enExport.note.length : 1;
-    });
 
     xml.on('endElement: note', (note: any) => {
       processNode(note);
@@ -49,7 +45,7 @@ export const parseStream = async (options: YarleOptions): Promise<void> => {
       const success = noteNumber - failed;
       console.log(
         `Conversion finished: ${success} succeeded, ${
-          totalNotes - success
+          noteNumber - success
         } failed.`,
       );
 


### PR DESCRIPTION
The current implementation of the console.log in the end of the conversion shows a negative number for failed notes if the enex includes more than one note. The reason is that `enExport.note` in this code snippet

```ts
    xml.on('startElement: en-export', (enExport: any) => {
      totalNotes = Array.isArray(enExport.note) ? enExport.note.length : 1;
    });
```

Was never an array (it was actually undefined) and therefore `totalNotes` was always 1. In any case we count the notes through noteNumber so this is actually not needed.

P. S.: It's a small fix but maybe you could also put the hacktoberfest-accepted label on this, if you accept it. Thanks! 👍 