### PR TITLE
Feat: Make it usable as a command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,13 @@
     "markdown",
     "enex to md"
   ],
-  "main": "./dropTheRope.js",
+  "main": "./dist/dropTheRope.js",
+  "bin": {
+    "yarle": "./dist/dropTheRope.js"
+  },
+  "files": [
+    "./dist/"
+  ],
   "scripts": {
     "build": "tsc --project ./src/tsconfig.json",
     "build:watch": "nodemon --watch src/ --exec \"npm run build\" -e ts",
@@ -57,9 +63,9 @@
   "license": "(MIT OR Apache-2.0)",
   "devDependencies": {
     "@types/he": "1.1.1",
-    "@types/marked": "1.1.0",
     "@types/jsdom": "16.2.4",
     "@types/lodash": "4.14.151",
+    "@types/marked": "1.1.0",
     "@types/minimist": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "14.0.1",

--- a/src/dropTheRope.ts
+++ b/src/dropTheRope.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node --max-old-space-size=1024
 /* istanbul ignore file */
 // tslint:disable:no-console
 
@@ -8,13 +9,13 @@ import * as yarle from './yarle';
 import { YarleOptions } from './YarleOptions';
 import { OutputFormat } from './output-format';
 
-export const run = async () => {
+export const run = async () => {
     const argv = minimist(process.argv.slice(2));
 
     const options: YarleOptions = {
         enexFile: argv['enexSource'],
         outputDir: argv['outputDir'],
-        isZettelkastenNeeded: argv['zettelkasten'] || false,
+        isZettelkastenNeeded: argv['zettelkasten'] || false,
         isMetadataNeeded: argv['include-metadata'] || false ,
         plainTextNotesOnly: argv['plaintext-notes-only'] || false ,
         skipLocation: argv['skip-latlng'] || false ,
@@ -32,7 +33,7 @@ export const run = async () => {
         const enexDir = options.enexFile;
         const enexFiles = fs
             .readdirSync(options.enexFile)
-            .filter(file => {
+            .filter(file => {
                 return file.match(/.*\.enex/ig);
             });
         for (const enexFile of enexFiles) {

--- a/src/utils/turndown-rules/filter-by-nodename.ts
+++ b/src/utils/turndown-rules/filter-by-nodename.ts
@@ -1,5 +1,5 @@
 export const filterByNodeName = (nodename: string): any => {
     return (node: any): any =>  {
-        return node.nodeName === nodename ||node.nodeName.toLowerCase() === nodename;
+        return node.nodeName === nodename || node.nodeName.toLowerCase() === nodename;
     };
 };


### PR DESCRIPTION
Closes #77 

In order to make yarle usable as a command we need to do the following things:

1. Add a bin and a files key to the package.json
2. Add a shebang to dropTheRope.ts

Now we can use yarle without the need to clone the repo, install and build it first.

```sh
npm i -g  yarle-evernote-to-md
yarle  --enexSource ./in/test-pdf.enex --outputDir=./out
```

or with npx:

```sh
npx -p  yarle-evernote-to-md yarle  --enexSource ./in/test-pdf.enex --outputDir=./out
```

To test this:

```sh
npm link
yarle  --enexSource ./in/test-pdf.enex --outputDir=./out
```