### PR TITLE
Add include-notebook-name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Those markdown notes that contains external resources such pictures or files, ar
  - ```--enexSource=<your-enex-file> or the folder of your enex files``` , specifies the exported Evernote notebook(s)
  - ```--outputDir=<relative_output_dir>``` , this is the main output dir in where the extracted markdown files are going to be created
  - ```--include-metadata``` , if it's set, then every markdown file will be extended by metadata (tags, time of creation, time of last update, lat-lon coordinates) 
+ - ```--include-notebook-name```, if set, every markdown file will include the .enex file name in the metadata section. This is useful if you export each notebook as a separate enex file and wish to have them organized in ObsidianMD (or similar). Requires '--include-metadata' to be set.
  - ```--zettelkasten``` , puts Zettelkasten Id (based on time of creation) at the beginning of the file name
  - ```--plaintext-notes-only``` , skips those notes, which has attachment, or picture in it.
  - ```--skip-latlng```, does not include location into metadata section

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yarle-evernote-to-md",
-  "version": "2.9.2",
+  "version": "2.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1933,6 +1933,7 @@
           "resolved": false,
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2299,7 +2300,8 @@
           "version": "1.1.6",
           "resolved": false,
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2395,6 +2397,7 @@
           "resolved": false,
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2447,7 +2450,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -2750,7 +2754,8 @@
           "version": "1.6.1",
           "resolved": false,
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/src/YarleOptions.ts
+++ b/src/YarleOptions.ts
@@ -1,9 +1,10 @@
 import { OutputFormat } from './output-format';
 
-export interface YarleOptions {
+export interface YarleOptions {
     enexFile?: string;
     outputDir?: string;
     isMetadataNeeded?: boolean;
+    isNotebookNameNeeded?: boolean;
     isZettelkastenNeeded?: boolean;
     plainTextNotesOnly?: boolean;
     skipLocation?: boolean;

--- a/src/dropTheRope.ts
+++ b/src/dropTheRope.ts
@@ -17,6 +17,7 @@ export const run = async () => {
         outputDir: argv['outputDir'],
         isZettelkastenNeeded: argv['zettelkasten'] || false,
         isMetadataNeeded: argv['include-metadata'] || false ,
+        isNotebookNameNeeded: argv['include-notebook-name'] || false ,
         plainTextNotesOnly: argv['plaintext-notes-only'] || false ,
         skipLocation: argv['skip-latlng'] || false ,
         skipCreationTime: argv['skip-creation-time'] || false ,

--- a/src/process-node.ts
+++ b/src/process-node.ts
@@ -1,11 +1,11 @@
 
-import { getComplexFilePath, getMetadata, getNoteContent, getSimpleFilePath, getTitle, isComplex, logTags } from './utils';
+import { getComplexFilePath, getMetadata, getNoteContent, getSimpleFilePath, getTitle, isComplex, logNotebookName, logTags, logSingleSeparator, logSectionSeparator } from './utils';
 import { yarleOptions } from './yarle';
 import { writeMdFile } from './utils/file-utils';
 import { processResources } from './process-resources';
 import { convertHtml2Md } from './convert-html-to-md';
 
-export const processNode = (note: any): void => {
+export const processNode = (note: any, notebookName: string): void => {
     const title = getTitle(note);
     // tslint:disable-next-line: no-console
     console.log(`Converting note ${title}...`);
@@ -15,10 +15,19 @@ export const processNode = (note: any): void => {
       const absFilePath = isComplex(note) ?
         getComplexFilePath(note) :
         getSimpleFilePath(note);
-
+        
+      const logTopMetadataSection = yarleOptions.isMetadataNeeded && 
+        (yarleOptions.isNotebookNameNeeded || (!yarleOptions.skipTags && note.tag))
+        
       data += title;
-      if (yarleOptions.isMetadataNeeded) {
+      if (logTopMetadataSection) {
+        data += logSectionSeparator();
+        if (yarleOptions.isNotebookNameNeeded) {
+          data += logNotebookName(notebookName);
+        }
         data += logTags(note);
+        data += logSectionSeparator();
+        data += logSingleSeparator();
       }
       if (isComplex(note)) {
         content = processResources(note, content);

--- a/src/utils/content-utils.ts
+++ b/src/utils/content-utils.ts
@@ -39,6 +39,10 @@ export const logLatLong = (note: any): string => {
           : '';
 };
 
+export const logNotebookName = (notebookName: string): string => {
+  return `Notebook: [[${notebookName}]]${EOL}`
+}
+
 export const logTags = (note: any): string => {
 
   if (!yarleOptions.skipTags && note.tag) {
@@ -49,15 +53,23 @@ export const logTags = (note: any): string => {
       return cleanTag.startsWith('#') ? cleanTag : `#${cleanTag}`;
     });
 
-    return `${EOL}${TAG_SECTION_SEPARATOR}${EOL}Tag(s): ${tags.join(' ')}${EOL}${EOL}${TAG_SECTION_SEPARATOR}${EOL}${EOL}`;
+    return `Tag(s): ${tags.join(' ')}${EOL}`;
   }
 
   return '';
 };
 
+export const logSingleSeparator = (): string => {
+  return `${EOL}`;
+};
+
 export const logSeparator = (): string => {
   return `${EOL}${EOL}`;
 };
+
+export const logSectionSeparator = (): string => {
+  return `${EOL}${TAG_SECTION_SEPARATOR}${EOL}`;
+}
 
 export const setFileDates = (path: string, note: any): void => {
   const modificationTime = moment(note.updated);

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -1,8 +1,9 @@
 import * as fs from 'fs';
+import * as util from 'util';
 
 import { setFileDates } from './content-utils';
 
-export const writeMdFile = (absFilePath: string, data: any, note: any): void =>Â {
+export const writeMdFile = (absFilePath: string, data: any, note: any): void => {
     try {
       fs.writeFileSync(absFilePath, data);
       setFileDates(absFilePath, note);
@@ -12,3 +13,4 @@ export const writeMdFile = (absFilePath: string, data: any, note: any): void =>Â
       throw e;
     }
   };
+

--- a/src/utils/filename-utils.ts
+++ b/src/utils/filename-utils.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as moment from 'moment';
+import * as path from 'path';
 
 import { yarleOptions } from '../yarle';
 
@@ -109,3 +110,8 @@ export const getNoteName = (dstPath: string, note: any): string => {
   return noteName;
 
 };
+
+export const getNotebookName = (enexFile: string): string => {
+  const notebookName = path.basename(enexFile, ".enex");
+  return notebookName;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 export * from './content-utils';
 export * from './filename-utils';
-export * from './folder-utils';
+export * from './folder-utils';
 export * from './note-utils';
 export * from './get-any-index';

--- a/src/yarle.ts
+++ b/src/yarle.ts
@@ -7,17 +7,20 @@ import { YarleOptions } from './YarleOptions';
 import { processNode } from './process-node';
 import { isWebClip } from './utils/note-utils';
 
-export let yarleOptions: YarleOptions = {
+export const defaultYarleOptions: YarleOptions = {
   enexFile: 'notebook.enex',
   outputDir: './mdNotes',
   isMetadataNeeded: false,
+  isNotebookNameNeeded: false,
   isZettelkastenNeeded: false,
   plainTextNotesOnly: false,
   skipWebClips: false,
 };
 
+export let yarleOptions: YarleOptions = { ...defaultYarleOptions };
+
 const setOptions = (options: YarleOptions): void => {
-  yarleOptions = { ...yarleOptions, ...options };
+  yarleOptions = { ...defaultYarleOptions, ...options };
 };
 
 export const parseStream = async (options: YarleOptions): Promise<void> => {
@@ -26,6 +29,8 @@ export const parseStream = async (options: YarleOptions): Promise<void> => {
   let noteNumber = 0;
   let failed = 0;
   let skipped = 0;
+  
+  const notebookName = utils.getNotebookName(options.enexFile);
 
   return new Promise((resolve, reject) => {
     const logAndReject = (error: Error) => {
@@ -43,7 +48,7 @@ export const parseStream = async (options: YarleOptions): Promise<void> => {
           ++skipped;
           console.log(`Notes skipped: ${skipped}`);
       } else {
-        processNode(note);
+        processNode(note, notebookName);
         ++noteNumber;
         console.log(`Notes processed: ${noteNumber}`);
       }

--- a/test/data/test-noteWithNotebookName.enex
+++ b/test/data/test-noteWithNotebookName.enex
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export3.dtd">
+<en-export export-date="20181006T112423Z" application="Evernote" version="Evernote Mac 7.5 (457109)">
+<note><title>TEST -note with text only</title><content><![CDATA[<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div>This is the content</div></en-note>]]></content><created>20181006T084349Z</created><updated>20181006T084411Z</updated><note-attributes><author>akos</author><source>desktop.mac</source><reminder-order>0</reminder-order></note-attributes></note>
+</en-export>

--- a/test/data/test-noteWithNotebookName.md
+++ b/test/data/test-noteWithNotebookName.md
@@ -1,0 +1,13 @@
+# TEST -note with text only
+
+---
+Notebook: [[test-noteWithNotebookName]]
+
+---
+
+This is the content
+
+    Created at: 2018-10-06T09:43:49+01:00
+    Updated at: 2018-10-06T09:44:11+01:00
+
+

--- a/test/data/test-noteWithNotebookNameAndTags.enex
+++ b/test/data/test-noteWithNotebookNameAndTags.enex
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export3.dtd">
+<en-export export-date="20181006T112423Z" application="Evernote" version="Evernote Mac 7.5 (457109)">
+<note><title>TEST -note with text only</title><content><![CDATA[<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div>This is the content</div></en-note>]]></content><created>20181006T084349Z</created><updated>20181006T084411Z</updated><tag>tag1</tag><tag>tag2</tag><note-attributes><author>akos</author><source>desktop.mac</source><reminder-order>0</reminder-order></note-attributes></note>
+</en-export>

--- a/test/data/test-noteWithNotebookNameAndTags.md
+++ b/test/data/test-noteWithNotebookNameAndTags.md
@@ -1,0 +1,14 @@
+# TEST -note with text only
+
+---
+Notebook: [[test-noteWithNotebookNameAndTags]]
+Tag(s): #tag1 #tag2
+
+---
+
+This is the content
+
+    Created at: 2018-10-06T09:43:49+01:00
+    Updated at: 2018-10-06T09:44:11+01:00
+
+

--- a/test/yarle.spec.ts
+++ b/test/yarle.spec.ts
@@ -144,6 +144,52 @@ describe('dropTheRope ', async () => {
       fs.readFileSync(`${__dirname}/data/test-noteWithTags.md`, 'utf8'),
     );
   });
+  
+  it('Note with notebook name', async () => {
+    const options: YarleOptions = {
+      enexFile: './test/data/test-noteWithNotebookName.enex',
+      outputDir: 'out',
+      isMetadataNeeded: true,
+      isNotebookNameNeeded: true,
+    };
+    await yarle.dropTheRope(options);
+    assert.equal(
+      fs.existsSync(
+        `${__dirname}/../out/simpleNotes/test-noteWithNotebookName/test -note with text only.md`,
+      ),
+      true,
+    );
+    assert.equal(
+      fs.readFileSync(
+        `${__dirname}/../out/simpleNotes/test-noteWithNotebookName/test -note with text only.md`,
+        'utf8',
+      ),
+      fs.readFileSync(`${__dirname}/data/test-noteWithNotebookName.md`, 'utf8'),
+    );
+  });
+  
+  it('Note with notebook name and tags', async () => {
+    const options: YarleOptions = {
+      enexFile: './test/data/test-noteWithNotebookNameAndTags.enex',
+      outputDir: 'out',
+      isMetadataNeeded: true,
+      isNotebookNameNeeded: true,
+    };
+    await yarle.dropTheRope(options);
+    assert.equal(
+      fs.existsSync(
+        `${__dirname}/../out/simpleNotes/test-noteWithNotebookNameAndTags/test -note with text only.md`,
+      ),
+      true,
+    );
+    assert.equal(
+      fs.readFileSync(
+        `${__dirname}/../out/simpleNotes/test-noteWithNotebookNameAndTags/test -note with text only.md`,
+        'utf8',
+      ),
+      fs.readFileSync(`${__dirname}/data/test-noteWithNotebookNameAndTags.md`, 'utf8'),
+    );
+  });
 
   it('Note with zettelkastel id', async () => {
     const options: YarleOptions = {


### PR DESCRIPTION
- Add new flag --include-notebook-name that when set includes the
basename of the enex file in the note. This is useful for keeping notes
semi-structured when using an editor such as ObsidianMD.
- Add tests for notebook name on it's own and notebook name + tags.
- Fix bug with yarleOptions causing tests to keep options between tests.

I prioritized backwards compatibility (ensuring no existing tests need modification) over code neatness. It might be worth changing the flags to have --skip-notebook-name similar to --skip-tags to make them more consistent. Same with changing the `EOF` placement. But this would require changing tests. 