### PR TITLE
Fix: Fix internal Links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 coverage
 node_modules
 dist
+in
 out
 .DS_Store
 .wakatime-project

--- a/src/convert-html-to-md.ts
+++ b/src/convert-html-to-md.ts
@@ -25,7 +25,8 @@ const fixSublists = (node: HTMLElement) => {
     liElements.forEach(liNode => {
       const listNodeDiv = liNode.firstElementChild;
       if (listNodeDiv && listNodeDiv.tagName === 'DIV') {
-        listNodeDiv.replaceWith(listNodeDiv.innerHTML);
+        const childElementsArr = Array.from(listNodeDiv.childNodes);
+        listNodeDiv.replaceWith(...childElementsArr);
       }
     });
 


### PR DESCRIPTION
Closes #78 

[See MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML) for the problem that innerHTML introduced here:

>If a <div>, <span>, or <noembed> node has a child text node that includes the characters (&), (<), or (>), innerHTML returns these characters as the HTML entities "&amp;", "&lt;" and "&gt;" respectively. Use Node.textContent to get a raw copy of these text nodes' contents.

Also the reason why I created an Array out of childNodes [is described here](https://github.com/microsoft/TypeScript/issues/2695).