### PR TITLE
Fix: Remove empty first line from fenced code blocks

### DIFF
--- a/src/utils/turndown-rules/code-block-rule.ts
+++ b/src/utils/turndown-rules/code-block-rule.ts
@@ -19,6 +19,10 @@ export const codeBlockRule = {
             return `${markdownBlock}${content}${markdownBlock}`;
         }
 
+        if (node.parentElement && isCodeBlock(node.parentElement) && node.parentElement.firstElementChild === node) {
+            return `${content}`;
+        }
+
         if (node.parentElement && isCodeBlock(node.parentElement)) {
             return `\n${content}`;
         }

--- a/test/data/test-noteWithCodeBlock.md
+++ b/test/data/test-noteWithCodeBlock.md
@@ -3,7 +3,6 @@
 Some text before the code block
 
 ```
-
 \# This program prints Hello, world in Python
 
 print('Hello, world!')
@@ -16,7 +15,6 @@ Some code after the code block 1
 One more longer code block
 
 ```
-
 // some Rust code...
 fn main() {
     for n in 1..=100 {

--- a/test/data/test-specialItems.md
+++ b/test/data/test-specialItems.md
@@ -10,7 +10,6 @@
 - [x] CheckedCheckbox2
 
 ```
-
 Inline Code 
 ```
 


### PR DESCRIPTION
Little fix to remove an empty line from a fenced code block.