### PR TITLE
Templates should work on all platforms

### DIFF
--- a/src/utils/templates/match-all.ts
+++ b/src/utils/templates/match-all.ts
@@ -1,1 +1,2 @@
-export const MATCH_ALL = '(.|\n|\r\n)*';
+export const MATCH_ALL = '(.|\r?\n)*';
+export const MATCH_LF = '\r?\n';

--- a/src/utils/templates/remove-functions/remove-placeholder.ts
+++ b/src/utils/templates/remove-functions/remove-placeholder.ts
@@ -1,10 +1,9 @@
-import { EOL } from 'os';
 import * as M from '../match-all';
 
 export const removePlaceholder = (text: string, P: any) : string => {
   return text.replace(
     new RegExp(
-      `${P.START_BLOCK}${M.MATCH_ALL}${P.END_BLOCK}${EOL}`,
+      `${P.START_BLOCK}${M.MATCH_ALL}${P.END_BLOCK}${M.MATCH_LF}`,
       'g',
     ),
     '',


### PR DESCRIPTION
 Yarle did not remove an unused template block, because I was using a template with Linux linefeeds under Windows.

It really should not matter which kind of EOL is in the template, i.e. you should be able to use a template with LF on Windows and vice versa a template with CRLF on Mac and Linux as well.