### PR TITLE
Create code fences from monospace font sections

### DIFF
--- a/src/utils/turndown-rules/code-block-rule.ts
+++ b/src/utils/turndown-rules/code-block-rule.ts
@@ -3,24 +3,72 @@ import { getAttributeProxy } from './get-attribute-proxy';
 
 const markdownBlock = '\n```\n';
 
-const isCodeBlock = (node: any)  => {
-    const nodeProxy = getAttributeProxy(node);
-    const codeBlockFlag = '-en-codeblock:true';
+const codeBlockFlag = '-en-codeblock:true';
+const reMonospaceFont =
+    /\b(Courier|Mono|Consolas|Console|Inconsolata|Pitch|Monaco|monospace)\b/;
 
-    return nodeProxy.style && nodeProxy.style.value.indexOf(codeBlockFlag) >= 0;
+const deepestFont: (node: any) => string = node => {
+    if (node.nodeType !== 1) {
+        return null;
+    }
+    const children = node.childNodes;
+    const numChildren = children.length;
+    if (numChildren > 1) {
+        return 'mixed';
+    }
+    if (numChildren === 1) {
+        const font = deepestFont(children[0]);
+        if (font) {
+            return font;
+        }
+    }
+    const nodeProxy = getAttributeProxy(node);
+    if (node.tagName === 'FONT') {
+        return nodeProxy.face?.value;
+    }
+    const style = nodeProxy.style?.value;
+    if (style) {
+        const match = style.match(/font-family:([^;]+)/);
+        if (match) {
+            return match[1];
+        }
+    }
+
+    return null;
+};
+
+const isCodeBlock: (node: any) => boolean = node => {
+    const nodeProxy = getAttributeProxy(node);
+    const style = nodeProxy.style?.value;
+    if (style && style.includes(codeBlockFlag)) {
+        return true;
+    }
+
+    const font = deepestFont(node);
+
+    return font && reMonospaceFont.test(font);
 };
 
 export const codeBlockRule = {
     filter: filterByNodeName('DIV'),
     replacement: (content: string, node: any) => {
-        const nodeProxy = getAttributeProxy(node);
-
         if (isCodeBlock(node)) {
-            return `${markdownBlock}${content}${markdownBlock}`;
+            const previous = node.previousSibling;
+            const previousIsBlock = previous && previous.tagName === node.tagName && isCodeBlock(previous);
+            const next = node.nextSibling;
+            const nextIsBlock = next && next.tagName === node.tagName && isCodeBlock(next);
+            if (previousIsBlock || nextIsBlock) {
+                content = previousIsBlock ? `\n${content}` : `${markdownBlock}${content}`;
+                content = nextIsBlock ? `${content}\n` : `${content}${markdownBlock}`;
+
+                return content;
+            }
+
+            return content.trim() ? `${markdownBlock}${content}${markdownBlock}` : content;
         }
 
         if (node.parentElement && isCodeBlock(node.parentElement) && node.parentElement.firstElementChild === node) {
-            return `${content}`;
+            return content;
         }
 
         if (node.parentElement && isCodeBlock(node.parentElement)) {


### PR DESCRIPTION
This PR is an attempt at solving #128.

The idea is to find blocks that are set in monospaced fonts only, and convert them into code fences.

It turned out that this is actually pretty difficult. The font can be set alternatively with "font face" or "font-family" in Evernote, and it could be overridden in deeper nested tags. Also we want to combine adjacent one-liner code blocks of this kind into a single one. We also do not want lines with mixed fonts, i.e. where only part of the line is monospace, to be interpreted as code blocks.

My PR tries to solve all of these issues, that's why it became a bit complicated.

There should be also tests and it should be optional behind a setting, but I haven't enough time to work on this. But I hope this PR at least can give an idea how to solve this.