### PR TITLE
Set creation time of Markdown files if possible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yarle-evernote-to-md",
-  "version": "3.1.1",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1792,6 +1792,11 @@
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
       }
+    },
+    "node-addon-api": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
+      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
     },
     "nodemon": {
       "version": "2.0.5",
@@ -3674,6 +3679,14 @@
       "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
       "requires": {
         "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "utimes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/utimes/-/utimes-4.0.2.tgz",
+      "integrity": "sha512-mE/6X4v+EFbFr+n3jvAH92qc1FKe1t0WIHdUU+pZ8IjkZdJQU1qFS76KmxlfUTZXLyrwvHHmedtLbWXIxE32fw==",
+      "requires": {
+        "node-addon-api": "^3.0.2"
       }
     },
     "ts-node": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "marked": "1.2.0",
     "md5-file": "5.0.0",
     "moment": "2.22.2",
+    "utimes": "4.0.2",
     "proxyquire": "2.1.3",
     "sanitize-filename": "^1.6.3",
     "ts-node": "8.5.4",

--- a/src/utils/content-utils.ts
+++ b/src/utils/content-utils.ts
@@ -1,5 +1,5 @@
 import Moment from 'moment';
-import fs from 'fs';
+import { utimes } from 'utimes';
 
 import { yarleOptions } from './../yarle';
 import { MetaData } from './../models/MetaData';
@@ -70,9 +70,10 @@ export const logTags = (note: any): string => {
 };
 
 export const setFileDates = (path: string, note: any): void => {
-  const modificationTime = Moment(note.updated);
-  const mtime = modificationTime.valueOf() / 1000;
-  fs.utimesSync(path, mtime, mtime);
+  const btime = Moment(note.created).valueOf();
+  const mtime = Moment(note.updated).valueOf();
+  const atime = mtime;
+  utimes(path, {btime, mtime, atime});
 };
 
 export const getTimeStampMoment = (resource: any): any => {

--- a/src/utils/content-utils.ts
+++ b/src/utils/content-utils.ts
@@ -1,4 +1,5 @@
 import Moment from 'moment';
+import { utimesSync } from 'fs'
 import { utimes } from 'utimes';
 
 import { yarleOptions } from './../yarle';
@@ -70,12 +71,14 @@ export const logTags = (note: any): string => {
 };
 
 export const setFileDates = (path: string, note: any): void => {
-  // set all time stamps (should work everywhere)
-  const mtime = Moment(note.updated).valueOf();
-  utimes(path, mtime);
-  // set birth time (silently ignored where unsupported)
-  const btime = Moment(note.created).valueOf();
-  utimes(path, {btime});
+  const updated = Moment(note.updated).valueOf();
+  const mtime = updated / 1000;
+  utimesSync(path, mtime, mtime);
+  // also set creation time where supported
+  const created = Moment(note.created).valueOf();
+  if (created && created !== updated) {
+    utimes(path, {btime: created});
+  }
 };
 
 export const getTimeStampMoment = (resource: any): any => {

--- a/src/utils/content-utils.ts
+++ b/src/utils/content-utils.ts
@@ -70,10 +70,12 @@ export const logTags = (note: any): string => {
 };
 
 export const setFileDates = (path: string, note: any): void => {
-  const btime = Moment(note.created).valueOf();
+  // set all time stamps (should work everywhere)
   const mtime = Moment(note.updated).valueOf();
-  const atime = mtime;
-  utimes(path, {btime, mtime, atime});
+  utimes(path, mtime);
+  // set birth time (silently ignored where unsupported)
+  const btime = Moment(note.created).valueOf();
+  utimes(path, {btime});
 };
 
 export const getTimeStampMoment = (resource: any): any => {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -29,14 +29,14 @@ describe('SetFileDates', () => {
 
     });
 
-    it('throw enoent in case of missing file', () => {
+    it('does not throw in case of missing file', () => {
         let errorHappened = false;
         try {
             utils.setFileDates('./test/data/do_not_exists.enex', notes['note']);
         } catch (e) {
             errorHappened = true;
         }
-        assert.equal(true, errorHappened);
+        assert.ok(!errorHappened);
 
     });
     it('set to now if no updated field in note',  () => {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -29,14 +29,14 @@ describe('SetFileDates', () => {
 
     });
 
-    it('does not throw in case of missing file', () => {
+    it('throws an error in case of a missing file', () => {
         let errorHappened = false;
         try {
             utils.setFileDates('./test/data/do_not_exists.enex', notes['note']);
         } catch (e) {
             errorHappened = true;
         }
-        assert.ok(!errorHappened);
+        assert.ok(errorHappened);
 
     });
     it('set to now if no updated field in note',  () => {


### PR DESCRIPTION
Use "utimes" to set the creation time of the created Markdown files,
using the creation time of the correspondihg note in Evernote.
Of course the operating system and file system must support this.

Works perfectly on Windows, where creation date is supported.
On Linux, it should work as before.

This should solve #127.