### PR TITLE
Improve execution instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A tool that converts enex note(s) into Markdown format in order to let you escap
 Just open a terminal, specify config options in a config file (options detailed in [Configuration](#Configuration)) and type the following: 
 
 ```javascript
-npx -p  yarle-evernote-to-md yarle  --configFile <path_to_your_file e.g. ./config.json>
+npx -p yarle-evernote-to-md@latest yarle --configFile <path_to_your_file e.g. ./config.json>
 ```
 
 ## Configuration:


### PR DESCRIPTION
Run npx with `@latest` because otherwise users may run an older version
from the npm cache that they had installed earlier.