### PR TITLE
Add an option to keep the original HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ A tool that converts enex note(s) into Markdown format in order to let you escap
 
  - Required [Install Node.js](https://nodejs.org/en/download/) version 10.22.1 or higher.
 
-## No-install execution 
-Just open a terminal, specify config options in a config file (options detailed in [Configuration](#Configuration)) and type the following: 
+## No-install execution
+Just open a terminal, specify config options in a config file (options detailed in [Configuration](#Configuration)) and type the following:
 
 ```javascript
 npx -p  yarle-evernote-to-md yarle  --configFile <path_to_your_file e.g. ./config.json>
@@ -34,6 +34,7 @@ To configure Yarle, you must create a config file. By default it looks like this
     "enexSource": "/absolute-path-of-your-enex-dir/test-template.enex",
     "templateFile": "/absolute-path-of-your-template-dir/sampleTemplate.tmpl",
     "outputDir": "out",
+    "keepOriginalHtml": false,
     "isMetadataNeeded": false,
     "isNotebookNameNeeded": false,
     "isZettelkastenNeeded": false,
@@ -49,13 +50,14 @@ To configure Yarle, you must create a config file. By default it looks like this
     "skipEnexFileNameFromOutputPath": false
 }
 ```
-The following configurational properties are available: 
+The following configurational properties are available:
 |
 |Property Name| Property value | Meaning |
 |-------------|----------------|---------|
 |```enexSource```| your enex file or the folder of your enex files | specifies the exported Evernote notebook(s) as an absolute path|
 |```templateFile``` | absolute path of your custom template file | if its not specified, a [default template](https://github.com/akosbalasko/yarle/blob/master/src/utils/templates/default-template.ts) will be used
 |```outputDir``` | relative path to your output dir | this is the main output dir where the extracted markdown files and the external resources, images, pdf-s are going to be created|
+|```keepOriginalHtml```| true or false | if set to true, then an additional HTML page that is an exact copy of the original note will be created in the `_resources` folder|
 |```isMetadataNeeded```| true or false | if it's set to true, then every Markdown file will be supplemented with metadata (tags, time of creation, time of last update, lat-lon coordinates) |
 |```isNotebookNameNeeded```|  true or false | if set, every Markdown file will include the .enex file name in the metadata section. This is useful if you export each notebook as a separate enex file and wish to have them organized in ObsidianMD (or similar). Requires '--include-metadata' to be set.|
 |```isZettelkastenNeeded``` |  true or false | puts Zettelkasten Id (based on time of creation) at the beginning of the file name|
@@ -67,8 +69,8 @@ The following configurational properties are available:
 |```skipTags```|  true or false | does not include tags in metadata section|
 |```useHashTags```|  true or false | whether to add the pound sign in front of tags|
 |```outputFormat```|  true or false | generates internal file links and highlights in Obsidian-style: highlights are going to be bounded by `==` instead of \` characters, file links are going to be as follows: `![[file-name]]` instead of `![file-name](file-name)`. Possible values: `ObsidianMD` to get Obsidian-style notes, `StandardMD` or skip it completely, if you prefer Standard Markdown format.|
-       
-### In program: 
+
+### In program:
 
 ```javascript
  const options: YarleOptions = {
@@ -83,17 +85,17 @@ The following configurational properties are available:
 ## Release notes
 
 ### Version 3.2.3
-- Changelog: 
+- Changelog:
    1. Template's path must be specified as absolute path in the config file
 
 ### Version 3.2.1
 
-- Changelog: 
+- Changelog:
    1. Code blocks are converted to Markdown fenced code blocks
    2. skipEnexFileNameFromOutputPath as config option introduced
    3. source url converted as metadata (see config options)
    4. Case sensitive fileNames
-   5. Some bugfixes 
+   5. Some bugfixes
 
 ### Version 3.1.0
 
@@ -107,7 +109,7 @@ The following configurational properties are available:
    2. Configuration is read from file instead of command line arguments, see [Configuration](#Configuration) for details.
    3. Easier usage, yarle as a command, see [Usage](#Usage) for details.
    5. Name of notebook is added as configuratble metadata option to be embedded into the note
-   6. Inclusion of web-clips is a configurable option 
+   6. Inclusion of web-clips is a configurable option
 
 - No more broken:
    1.  Mayor set of fixes around internal links, check [this umbrella-issue](https://github.com/akosbalasko/yarle/issues/92) about the changes.
@@ -116,26 +118,26 @@ The following configurational properties are available:
 
 ### Version 2.11.0
 
-- Features: 
+- Features:
    1. Webclipped notes, namely articles, simplified articles, bookmarks, screenshots scraped by Evernote's web clipper are converted
    2. UrlEncodeMD introduced as possible value of 'outputFormat' property, it makes image links be url-encoded in markdown notes, thx to [Martin Hähnel](https://github.com/finn-matti)
    3. Links in headers supported
 
-- Fixes: 
+- Fixes:
    1. [Memory leak issue](https://github.com/akosbalasko/yarle/issues/55)
    2. [List items indented correctly](https://github.com/akosbalasko/yarle/issues/60), thx to [Martin Hähnel](https://github.com/finn-matti)
    3. [Bug of multiple links point to the same resource fixed](https://github.com/akosbalasko/yarle/issues/56)
    4. [Required node version clarification](https://github.com/akosbalasko/yarle/pull/59), thx to [Mesc](https://github.com/mescalito)
- 
 
-### Version 2.9.2 
+
+### Version 2.9.2
 
 - [Issue#49](https://github.com/akosbalasko/yarle/issues/49) fixed
 - [Issue#53](https://github.com/akosbalasko/yarle/issues/53) fixed
 
 ### Version 2.9.1
 
-- Enclosing brackets around links are removed to avoid causing troubles in MD file (fixes: [Issue#50](https://github.com/akosbalasko/yarle/issues/50)) 
+- Enclosing brackets around links are removed to avoid causing troubles in MD file (fixes: [Issue#50](https://github.com/akosbalasko/yarle/issues/50))
 
 ### Version 2.9.0
 
@@ -146,16 +148,16 @@ The following configurational properties are available:
 - Bug reported in [Issue#39](https://github.com/akosbalasko/yarle/issues/39) fixed.
 - Action added to test Yarle in different Node versions.
 
-Special thanks to [Rodrigo Vieira](https://github.com/rodbv) for the contribution!  
+Special thanks to [Rodrigo Vieira](https://github.com/rodbv) for the contribution!
 
 ### Version 2.8.0
 
-- New command-line argument introduced : `--outputFormat`.  Its optional, one possible value is `ObsidianMD` that configures Yarle to generate internal file links and highlights in Obsidian-style. 
+- New command-line argument introduced : `--outputFormat`.  Its optional, one possible value is `ObsidianMD` that configures Yarle to generate internal file links and highlights in Obsidian-style.
 
 ### Version 2.7.0
 
  - Huge performance improvement, works with enex files that contain 2k+ notes
- - Bugfix: generates OS-friendly file and folder names 
+ - Bugfix: generates OS-friendly file and folder names
 
 ### Version 2.6.6
 
@@ -164,15 +166,15 @@ Special thanks to [Rodrigo Vieira](https://github.com/rodbv) for the contributio
 
 ### Version 2.6.5
 
- - Bugfix: handling internal resource files (with no filenames) correctly 
-  
+ - Bugfix: handling internal resource files (with no filenames) correctly
+
 ### Version 2.6.4
 
- - Small bugfixes 
+ - Small bugfixes
 
 ### Version 2.6.1
 
- - Attached images are converted as standard Markdown images instead of as wikistyle-links. 
+ - Attached images are converted as standard Markdown images instead of as wikistyle-links.
 
 ### Version 2.6.0
 
@@ -182,32 +184,32 @@ Special thanks to [Rodrigo Vieira](https://github.com/rodbv) for the contributio
 ### Version 2.5.0
 
  - Generating links in wiki-style links is supported by default, its command line argument is removed.
- - Evernote's internal links among the notes are supported in the case if the **note title** and **its created reference** is the same text.  
+ - Evernote's internal links among the notes are supported in the case if the **note title** and **its created reference** is the same text.
 
 ### Version 2.4.1
 
-As a hotfix notes within resources (e.g. web clips) are skipped to be referenced from the generated Markdown files. 
+As a hotfix notes within resources (e.g. web clips) are skipped to be referenced from the generated Markdown files.
 
 
 ### Version 2.4.0
 
- - Folders can be added as input, in this case all the enex files within this folder will be transformed 
+ - Folders can be added as input, in this case all the enex files within this folder will be transformed
  - Zettelkasten IDs are unique, if multiple notes has been created in the same minute, then they will be indexed by numbers starting from 1 (except the first, it has no index)
- 
+
 ### Version 2.3.2
 
  - Bugfix: untitled notes' title is removed from the generated filename if Zettelkasten is required.
- - Bugfix: tags are moved to the top and # added as prefix for each if it's missing. 
+ - Bugfix: tags are moved to the top and # added as prefix for each if it's missing.
 
 
 ### Version 2.3.0
 
  - Skipping parts of metadata in configurable via options
-  
+
 ### Version 2.2.0
 
  - Links are generated in wiki-style links ([[link]]) if `--wikistyle-media-links` option is set
- - Bugfix: Notes with single resources are exported fine 
+ - Bugfix: Notes with single resources are exported fine
  - Codebase refactored
 
 
@@ -219,7 +221,7 @@ As a hotfix notes within resources (e.g. web clips) are skipped to be referenced
 
  - plaintext-notes-only command line argument added, that enables you to skip converting notes with any resources, pictures, pdf, etc.
 
-### Version 2.0.1: 
+### Version 2.0.1:
 
  - The whole tool is reimplemented in Typescript
  - ZettelKasten ID is an option for filename generation (format is <id>|(pipe) <title>.md or <id>.md if there is no title)

--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
     "enexSource": "/test/data/test-template.enex",
     "templateFile": "/sampleTemplate.tmpl",
     "outputDir": "out",
+    "keepOriginalHtml": false,
     "isMetadataNeeded": false,
     "isNotebookNameNeeded": false,
     "isZettelkastenNeeded": false,

--- a/src/YarleOptions.ts
+++ b/src/YarleOptions.ts
@@ -4,6 +4,7 @@ export interface YarleOptions {
     enexSource?: string;
     templateFile?: string;
     outputDir?: string;
+    keepOriginalHtml?: boolean;
     isMetadataNeeded?: boolean;
     isNotebookNameNeeded?: boolean;
     isZettelkastenNeeded?: boolean;

--- a/src/convert-to-html.ts
+++ b/src/convert-to-html.ts
@@ -1,0 +1,72 @@
+import { yarleOptions } from './yarle';
+import { NoteData } from './models/NoteData';
+
+const fontFamily = 'Arial,"Helvetica Neue",Helvetica,sans-serif';
+const fontSize = '12pt';
+
+export const convert2Html = (content: string, noteData: NoteData): string => {
+  if (!yarleOptions.keepOriginalHtml) {
+    return null;
+  }
+  const m = content.match(/<en-note(| [^>]*)>([\s\S]*)<\/en-note>/);
+  if (!m) {
+    return null;
+  }
+  content = `<div${m[1]}>${m[2]}</div>`;
+  content = content.replace(/<(a href|img src)=".\/_resources\//, '<$1="./')
+  let url = noteData.sourceUrl;
+  if (url) {
+    url = `<a href="${url}">${url.replace('&', '&amp;')}</a>`;
+  }
+  let tags = noteData.tags;
+  if (tags) {
+      tags = tags.split(' ').join(', ');
+  }
+  const trs = [
+    ['Created', noteData.createdAt],
+    ['Updated', noteData.updatedAt],
+    ['Location', noteData.location],
+    ['Source', url],
+    ['Tags', tags],
+  ].filter(r => r[1])
+    .reduce((p, c) => `${p}\n<tr><th>${c[0]}:</th><td>${c[1]}</td></tr>`, '');
+
+  return `<!DOCTYPE html>
+<head>
+<title>${noteData.title}</title>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+
+<style>
+body {
+padding: 1em;
+color: #080808;
+background-color: #f8f8f8;
+}
+body, td, th {
+font-family: ${fontFamily};
+font-size: ${fontSize};
+}
+table.meta {
+margin-bottom: 3em;
+border-collapse: collapse;
+}
+table.meta th {
+text-align: left;
+}
+table.meta th, table.meta td {
+padding: 2pt 4pt;
+background-color: #D4DDE5;
+border: 1px solid #444444;
+font-size: 10pt;
+}
+</style>
+</head>
+<body>
+<h1>${noteData.title}</h1>
+<div>
+<table class="meta">${trs}
+</table>
+${content}
+</body>
+</html>`;
+  }

--- a/src/models/MetaData.ts
+++ b/src/models/MetaData.ts
@@ -3,5 +3,6 @@ export interface MetaData {
     updatedAt?: string;
     sourceUrl?: string;
     location?: string;
+    linkToOriginal?: string;
     notebookName?: string;
   }

--- a/src/models/NoteData.ts
+++ b/src/models/NoteData.ts
@@ -6,5 +6,6 @@ export interface NoteData {
     updatedAt?: string;
     sourceUrl?: string;
     location?: string;
+    linkToOriginal?: string;
     notebookName?: string;
   }

--- a/src/process-node.ts
+++ b/src/process-node.ts
@@ -1,5 +1,6 @@
 import { applyTemplate } from './utils/templates/templates';
 import {
+  getHtmlFilePath,
   getMdFilePath,
   getMetadata,
   getNoteContent,
@@ -7,9 +8,10 @@ import {
   isComplex,
 } from './utils';
 import { yarleOptions } from './yarle';
-import { writeMdFile } from './utils/file-utils';
+import { writeFile } from './utils/file-utils';
 import { processResources } from './process-resources';
 import { convertHtml2Md } from './convert-html-to-md';
+import { convert2Html } from './convert-to-html';
 import { NoteData } from './models/NoteData';
 
 export const processNode = (note: any, notebookName: string): void => {
@@ -29,14 +31,20 @@ export const processNode = (note: any, notebookName: string): void => {
     noteData = {...noteData, ...getMetadata(note, notebookName)};
     noteData = {...noteData, ...getTags(note)};
 
-    const data = applyTemplate(noteData, yarleOptions);
-
-    const absFilePath = getMdFilePath(note);
+    let data = applyTemplate(noteData, yarleOptions);
+    let absFilePath = getMdFilePath(note);
 
     // tslint:disable-next-line:no-console
     console.log('data =>\n', JSON.stringify(data), '\n***');
 
-    writeMdFile(absFilePath, data, note);
+    writeFile(absFilePath, data, note);
+
+    data = convert2Html(content, noteData);
+    if (data) {
+        absFilePath = getHtmlFilePath(note);
+        writeFile(absFilePath, data, note);
+    }
+
   } catch (e) {
     // tslint:disable-next-line:no-console
     console.log(`Failed to convert note: ${noteData.title}`, e);

--- a/src/process-resources.ts
+++ b/src/process-resources.ts
@@ -43,7 +43,7 @@ const addMediaReference = (content: string, resourceHashes: any, hash: any, rela
   updatedContent = (matchedElements && matchedElements.length > 0 &&
     matchedElements[0].split('type=').length > 1 &&
     matchedElements[0].split('type=')[1].startsWith('"image')) ?
-    content.replace(re, `<img alt="${resourceHashes[hash].fileName}" src="${src}">`) :
+    content.replace(re, `<img src="${src}" alt="${resourceHashes[hash].fileName}">`) :
     content.replace(re, `<a href="${src}">${resourceHashes[hash].fileName}</a>`);
 
   return updatedContent;

--- a/src/utils/content-utils.ts
+++ b/src/utils/content-utils.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { yarleOptions } from './../yarle';
 import { MetaData } from './../models/MetaData';
 import { NoteData } from './../models';
+import { getHtmlFileLink } from './folder-utils';
 
 export const getMetadata = (note: any, notebookName: string): MetaData => {
 
@@ -13,6 +14,7 @@ export const getMetadata = (note: any, notebookName: string): MetaData => {
         updatedAt: getUpdateTime(note),
         sourceUrl: getSourceUrl(note),
         location: getLatLong(note),
+        linkToOriginal: getLinkToOriginal(note),
         notebookName,
       }
     : {
@@ -40,6 +42,11 @@ export const getSourceUrl = (note: any): string => {
     note['note-attributes']
     ? note['note-attributes']['source-url']
     : undefined;
+};
+
+export const getLinkToOriginal = (note: any): string => {
+  return yarleOptions.keepOriginalHtml ?
+    getHtmlFileLink(note) : undefined;
 };
 
 export const getLatLong = (note: any): string => {

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 
 import { setFileDates } from './content-utils';
 
-export const writeMdFile = (absFilePath: string, data: any, note: any): void => {
+export const writeFile = (absFilePath: string, data: any, note: any): void => {
     try {
       fs.writeFileSync(absFilePath, data);
       setFileDates(absFilePath, note);
@@ -12,4 +12,3 @@ export const writeMdFile = (absFilePath: string, data: any, note: any): void => 
       throw e;
     }
   };
-

--- a/src/utils/folder-utils.ts
+++ b/src/utils/folder-utils.ts
@@ -10,17 +10,24 @@ export const paths: Path = {};
 
 export const getResourceDir = (dstPath: string, note: any): string => {
   return getNoteName(dstPath, note).replace(/\s/g, '_');
-
 };
 
 const getFilePath = (dstPath: string, note: any): string => {
-
   return `${dstPath}/${getNoteFileName(dstPath, note)}`;
 };
 
 export const getMdFilePath = (note: any): string => {
-
   return getFilePath(paths.mdPath, note);
+};
+
+export const getHtmlFilePath = (note: any): string => {
+  return getFilePath(paths.resourcePath, note).replace(/\.md$/, '.html');
+};
+
+export const getHtmlFileLink = (note: any): string => {
+  const path = getHtmlFilePath(note);
+
+  return `.${path.slice(paths.resourcePath.lastIndexOf('/'))}`;
 };
 
 const clearDistDir = (dstPath: string): void => {

--- a/src/utils/templates/apply-functions/apply-original-template.ts
+++ b/src/utils/templates/apply-functions/apply-original-template.ts
@@ -1,0 +1,7 @@
+import { NoteData } from '../../../models/NoteData';
+import * as P from '../placeholders/original-placeholders';
+import { applyConditionalTemplate } from './apply-conditional-template';
+
+export const applyLinkToOriginalTemplate = (noteData: NoteData, text: string): string => {
+    return applyConditionalTemplate(text, P, noteData.linkToOriginal);
+};

--- a/src/utils/templates/apply-functions/index.ts
+++ b/src/utils/templates/apply-functions/index.ts
@@ -5,4 +5,5 @@ export * from './apply-createdat-template';
 export * from './apply-updatedat-template';
 export * from './apply-sourceurl-template';
 export * from './apply-location-template';
+export * from './apply-original-template';
 export * from './apply-notebook-template';

--- a/src/utils/templates/placeholders/original-placeholders.ts
+++ b/src/utils/templates/placeholders/original-placeholders.ts
@@ -1,0 +1,3 @@
+export const CONTENT_PLACEHOLDER = '{link-to-original}';
+export const START_BLOCK = '{link-to-original-block}';
+export const END_BLOCK = '{end-link-to-original-block}';

--- a/src/utils/templates/templates.ts
+++ b/src/utils/templates/templates.ts
@@ -4,22 +4,25 @@ import { defaultTemplate } from './default-template';
 import { YarleOptions } from '../../YarleOptions';
 import { NoteData } from '../../models/NoteData';
 import {
-  applyTitleTemplate,
-  applyTagsTemplate,
   applyContentTemplate,
   applyCreatedAtTemplate,
-  applyUpdatedAtTemplate,
-  applySourceUrlTemplate,
+  applyLinkToOriginalTemplate,
   applyLocationTemplate,
-  applyNotebookTemplate } from './apply-functions';
+  applyNotebookTemplate,
+  applySourceUrlTemplate,
+  applyTagsTemplate,
+  applyTitleTemplate,
+  applyUpdatedAtTemplate,
+  } from './apply-functions';
 
 import {
-  removeUpdatedAtPlaceholder,
   removeCreatedAtPlaceholder,
-  removeSourceUrlPlaceholder,
   removeLocationPlaceholder,
+  removeMetadataBlockPlaceholder,
   removeNotebookPlaceholder,
-  removeMetadataBlockPlaceholder } from './remove-functions';
+  removeSourceUrlPlaceholder,
+  removeUpdatedAtPlaceholder,
+ } from './remove-functions';
 
 export const applyTemplate = (noteData: NoteData, yarleOptions: YarleOptions) => {
   let result = defaultTemplate;
@@ -31,6 +34,7 @@ export const applyTemplate = (noteData: NoteData, yarleOptions: YarleOptions) =>
   result = applyTitleTemplate(noteData, result, () => noteData.title);
   result = applyTagsTemplate(noteData, result, () => !yarleOptions.skipTags);
   result = applyContentTemplate(noteData, result, () => noteData.content);
+  result = applyLinkToOriginalTemplate(noteData, result);
 
   if (yarleOptions.isMetadataNeeded) {
 

--- a/src/yarle.ts
+++ b/src/yarle.ts
@@ -9,6 +9,7 @@ import { isWebClip } from './utils/note-utils';
 export const defaultYarleOptions: YarleOptions = {
   enexSource: 'notebook.enex',
   outputDir: './mdNotes',
+  keepOriginalHtml: false,
   isMetadataNeeded: false,
   isNotebookNameNeeded: false,
   isZettelkastenNeeded: false,


### PR DESCRIPTION
closes: https://github.com/akosbalasko/yarle/issues/81

This PR tries to implement the feature requested in #81.

When the new setting `keepOriginalHtml` is set to true, then for every Markdown file that is created, an HTML file will also be created in the `_resources` folder which is an exact copy of the original note in Evernote (pretty similar to what the Evernote client exports when you choose HTML format instead of ENEX).

I have also added a new template block `link-to-original` that allows adding a link to the original HTML in the Markdown file.

This makes the decision easier to ditch Evernote completely, because you don't need to fear losses in the  conversion from HTML to Markdown if you can always view the original in case of doubt. Also, in some cases the original formatting may be nicer than the formatting after conversion to Markdown.