### PR TITLE
Fix a problem with self-closing anchor tags (#140).

### DIFF
--- a/src/convert-html-to-md.ts
+++ b/src/convert-html-to-md.ts
@@ -36,7 +36,10 @@ const fixSublists = (node: HTMLElement) => {
 };
 
 export const convertHtml2Md = (content: string): NoteData => {
-    const contentNode = new JSDOM(`<x-turndown id="turndown-root">${content}</x-turndown>`).window.document.getElementById('turndown-root');
+    content = content.replace(/<!DOCTYPE en-note [^>]*>/, '<!DOCTYPE html>')
+      .replace(/(<a [^>]*)\/>/, '$1></a>');
+    const contentNode = new JSDOM(content).window.document
+      .getElementsByTagName('en-note').item(0) as any as HTMLElement;
     const contentInMd = getTurndownService(yarleOptions).turndown(fixSublists(contentNode));
 
     return contentInMd && contentInMd !== 'undefined' ? { content: contentInMd } : {content: ''};

--- a/src/utils/turndown-rules/internal-links-rule.ts
+++ b/src/utils/turndown-rules/internal-links-rule.ts
@@ -15,62 +15,64 @@ export const wikiStyleLinksRule = {
     filter: filterByNodeName('A'),
     replacement: (content: any, node: any) => {
         const nodeProxy = getAttributeProxy(node);
-        if (nodeProxy.href) {
-            /*internalLink [[]]
-            realLink []()
-            anchor [[a#v|c]]
-            */
-            /*if (nodeProxy.href.value.startsWith('evernote://'))
-                return `[[${removeBrackets(node.innerHTML)}]]`
-            else*/
-            const internalTurndownedContent = getTurndownService(yarleOptions).turndown(removeBrackets(node.innerHTML));
-            const lexer = new marked.Lexer({});
-            const tokens = lexer.lex(internalTurndownedContent) as any;
-            let token: any = {
-                mdKeyword: '',
-                text: internalTurndownedContent,
-            };
-            if (tokens.length > 0 && tokens[0]['type'] === 'heading') {
-                token = tokens[0];
-                token['mdKeyword'] = `${'#'.repeat(tokens[0]['depth'])} `;
-            }
-
-            if (nodeProxy.href.value.startsWith('http') ||
-                nodeProxy.href.value.startsWith('www') ||
-                nodeProxy.href.value.startsWith('file')) {
-
-                    return `${token['mdKeyword']}[${token['text']}](${nodeProxy.href.value})`;
-                }
-            if (nodeProxy.href.value.startsWith('evernote://')) {
-                const fileName = normalizeTitle(token['text']);
-                const displayName = token['text'];
-                if (yarleOptions.outputFormat === OutputFormat.ObsidianMD) {
-                    return `${token['mdKeyword']}[[${fileName}|${displayName}]]`;
-                }
-
-                if (yarleOptions.outputFormat === OutputFormat.UrlEncodeMD) {
-                    return  `${token['mdKeyword']}[${displayName}](${encodeURI(fileName)})`;
-                }
-
-                return  `${token['mdKeyword']}[${displayName}](${fileName})`;
-
-            }
-
-            return (yarleOptions.outputFormat === OutputFormat.ObsidianMD)
-            ? `${token['mdKeyword']}[[${nodeProxy.href.value} | ${token['text']}]]`
-            : `${token['mdKeyword']}[[${nodeProxy.href.value}]]`;
-            // todo embed
-
-            /*return (
-                (!nodeProxy.href.value.startsWith('http') &&
-                 !nodeProxy.href.value.startsWith('www')) ||
-                 nodeProxy.href.value.startsWith('evernote://')
-                )
-                ? `[[${removeBrackets(node.innerHTML)}]]`
-                : (yarleOptions.outputFormat === OutputFormat.ObsidianMD)
-                    ? `![[${removeBrackets(node.innerHTML)}]]`
-                    : `[${removeBrackets(node.innerHTML)}](${nodeProxy.href.value})`;
-            */
+        if (!nodeProxy.href) {
+            return '';
         }
+
+        /*internalLink [[]]
+        realLink []()
+        anchor [[a#v|c]]
+        */
+        /*if (nodeProxy.href.value.startsWith('evernote://'))
+            return `[[${removeBrackets(node.innerHTML)}]]`
+        else*/
+        const internalTurndownedContent = getTurndownService(yarleOptions).turndown(removeBrackets(node.innerHTML));
+        const lexer = new marked.Lexer({});
+        const tokens = lexer.lex(internalTurndownedContent) as any;
+        let token: any = {
+            mdKeyword: '',
+            text: internalTurndownedContent,
+        };
+        if (tokens.length > 0 && tokens[0]['type'] === 'heading') {
+            token = tokens[0];
+            token['mdKeyword'] = `${'#'.repeat(tokens[0]['depth'])} `;
+        }
+
+        if (nodeProxy.href.value.startsWith('http') ||
+            nodeProxy.href.value.startsWith('www') ||
+            nodeProxy.href.value.startsWith('file')) {
+
+                return `${token['mdKeyword']}[${token['text']}](${nodeProxy.href.value})`;
+            }
+        if (nodeProxy.href.value.startsWith('evernote://')) {
+            const fileName = normalizeTitle(token['text']);
+            const displayName = token['text'];
+            if (yarleOptions.outputFormat === OutputFormat.ObsidianMD) {
+                return `${token['mdKeyword']}[[${fileName}|${displayName}]]`;
+            }
+
+            if (yarleOptions.outputFormat === OutputFormat.UrlEncodeMD) {
+                return  `${token['mdKeyword']}[${displayName}](${encodeURI(fileName)})`;
+            }
+
+            return  `${token['mdKeyword']}[${displayName}](${fileName})`;
+
+        }
+
+        return (yarleOptions.outputFormat === OutputFormat.ObsidianMD)
+        ? `${token['mdKeyword']}[[${nodeProxy.href.value} | ${token['text']}]]`
+        : `${token['mdKeyword']}[[${nodeProxy.href.value}]]`;
+        // todo embed
+
+        /*return (
+            (!nodeProxy.href.value.startsWith('http') &&
+                !nodeProxy.href.value.startsWith('www')) ||
+                nodeProxy.href.value.startsWith('evernote://')
+            )
+            ? `[[${removeBrackets(node.innerHTML)}]]`
+            : (yarleOptions.outputFormat === OutputFormat.ObsidianMD)
+                ? `![[${removeBrackets(node.innerHTML)}]]`
+                : `[${removeBrackets(node.innerHTML)}](${nodeProxy.href.value})`;
+        */
     },
 };


### PR DESCRIPTION
See issue #140 for the problem I'm trying to solve here.

First tried calling JSDOM with a contentType of `text/xml` or `application/xhtml+xml`. This solved the issue, but then there were error messages complaining about "unknown entities" when the notes contained named entities such as `&nbsp;`.

So I solved the problem with a simple replacement of self-closing anchor tags, adding an explicit closing tag.

Maybe there are better solutions. We should probably also add a unit test.

Note that the change to `internal-links-rule.ts` is really simple: Return an empty string instead of  `undefind` when there is no `href` attribute. This removes the `undefined`, but would still swallow text without the fix in `convert-html-to-md.ts`.