### PR TITLE
Use 24 hour time instead of 12 hour time for the Zettelkasten ID

### DIFF
--- a/src/utils/filename-utils.ts
+++ b/src/utils/filename-utils.ts
@@ -81,7 +81,7 @@ export const getExtension = (resource: any): string => {
 };
 
 export const getZettelKastelId = (note: any, dstPath: string): string => {
-  return Moment(note['created']).format('YYYYMMDDhhmm');
+  return Moment(note['created']).format('YYYYMMDDHHmm');
 
 };
 


### PR DESCRIPTION
Because the 12 hour time is ambiguous without am/pm.