### PR TITLE
Use double-bracket notation only for local images

### DIFF
--- a/src/utils/turndown-rules/images-rule.ts
+++ b/src/utils/turndown-rules/images-rule.ts
@@ -12,16 +12,18 @@ export const imagesRule = {
     if (!nodeProxy.src) {
       return '';
     }
+    const value = nodeProxy.src.value;
 
-    if (yarleOptions.outputFormat === OutputFormat.ObsidianMD) {
-      return `![[${nodeProxy.src.value}]]`;
+    if (yarleOptions.outputFormat === OutputFormat.ObsidianMD &&
+        !value.match(/^[a-z]+:/)) {
+      return `![[${value}]]`;
     }
 
     const srcSpl = nodeProxy.src.value.split('/');
     if (yarleOptions.outputFormat === OutputFormat.UrlEncodeMD) {
-      return `![${srcSpl[srcSpl.length - 1]}](${encodeURI(nodeProxy.src.value)})`;
+      return `![${srcSpl[srcSpl.length - 1]}](${encodeURI(value)})`;
     }
 
-    return `![${srcSpl[srcSpl.length - 1]}](${nodeProxy.src.value})`;
+    return `![${srcSpl[srcSpl.length - 1]}](${value})`;
   },
 };


### PR DESCRIPTION
Obsidian does not support the double-bracket notation for external images.
If the source URL is prefixed with a scheme, we need to use standard Markdown.