### PR TITLE
Fix issue when there is only one note-attribute

### DIFF
--- a/src/process-node.ts
+++ b/src/process-node.ts
@@ -1,12 +1,10 @@
 import { applyTemplate } from './utils/templates/templates';
 import {
-  getHtmlFilePath,
-  getMdFilePath,
   getMetadata,
-  saveHtmlFile,
-  saveMdFile,
   getTags,
   isComplex,
+  saveHtmlFile,
+  saveMdFile,
 } from './utils';
 import { yarleOptions } from './yarle';
 import { processResources } from './process-resources';
@@ -26,7 +24,6 @@ export const processNode = (note: any, notebookName: string): void => {
   console.log(`Converting note ${noteData.title}...`);
 
   try {
-    
     if (isComplex(note)) {
       noteData.htmlContent = processResources(note);
     }

--- a/src/utils/templates/default-template.ts
+++ b/src/utils/templates/default-template.ts
@@ -10,6 +10,7 @@ Tag(s): {tags}
 {created-at-block}    Created at: {created-at}{end-created-at-block}
 {updated-at-block}    Updated at: {updated-at}{end-updated-at-block}
 {location-block}    Where: {location}{end-location-block}
+{source-url-block}    Source URL: {source-url}{end-source-url-block}
 {notebook-block}    Notebook: {notebook}{end-notebook-block}
 {end-metadata-block}
 `;

--- a/test/data/test-imageWithoutSrc.md
+++ b/test/data/test-imageWithoutSrc.md
@@ -64,4 +64,5 @@ Some of my qualifications may not be obvious at the moment (e.g. how can scalabi
 
     Created at: 2020-01-13T18:38:07+00:00
     Updated at: 2020-08-30T18:46:33+01:00
+    Source URL: https://medium.com/@nmckinnonblog/microservices-42b09caeb73d
 

--- a/test/data/test-noteWithSourceUrl.enex
+++ b/test/data/test-noteWithSourceUrl.enex
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export3.dtd">
+<en-export export-date="20181006T114811Z" application="Evernote" version="Evernote Mac 7.5 (457109)">
+<note><title>Test</title><content><![CDATA[<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div>note with source-url</div></en-note>]]></content><created>20181006T114658Z</created><updated>20181006T114658Z</updated><note-attributes><source-url>https://en.wikipedia.org/wiki/Evernote</source-url></note-attributes></note>
+</en-export>

--- a/test/data/test-noteWithSourceUrl.md
+++ b/test/data/test-noteWithSourceUrl.md
@@ -1,0 +1,8 @@
+# Test
+
+note with source-url
+
+    Created at: 2018-10-06T12:46:58+01:00
+    Updated at: 2018-10-06T12:46:58+01:00
+    Source URL: https://en.wikipedia.org/wiki/Evernote
+

--- a/test/data/test-webclip_article.md
+++ b/test/data/test-webclip_article.md
@@ -117,4 +117,5 @@ sharer.js, passport-evernote-auth, passport-evernote, share-buttons, _yarle_\-_e
 
     Created at: 2020-10-18T08:25:40+01:00
     Updated at: 2020-10-18T08:25:40+01:00
+    Source URL: https://www.google.com/search?sxsrf=ALeKk03bpXQ9mBvZPr4siq9b90rD9F_scA%3A1603005812287&ei=dO2LX9qUEcX1qwGn5brgBQ&q=yarle+evernote&oq=yarle+evernote&gs_lcp=CgZwc3ktYWIQAzIECCMQJzoHCCMQsAMQJzoHCAAQsAMQQzoHCC4QsAMQQzoJCAAQsAMQBxAeOgcIABCwAxAKOgUIABDJAzoCCAA6BAgAEAo6BAguEAo6BwguEMkDEA06BggAEA0QCjoGCAAQDRAeOggIABANEAoQHjoICAAQDRAFEB46CAgAEBYQChAeOgUIIRCgAToHCAAQyQMQDToECAAQDVDdEViJKmD_MGgDcAB4AYAB7gSIAf0RkgEJMC45LjEuNS0xmAEAoAEBqgEHZ3dzLXdpesgBCsABAQ&sclient=psy-ab&ved=0ahUKEwjano6Azr3sAhXF-ioKHaeyDlwQ4dUDCA0&uact=5
 

--- a/test/data/test-webclip_bookmark.md
+++ b/test/data/test-webclip_bookmark.md
@@ -8,4 +8,5 @@ Yet Another Rope Ladder from Evernote. Contribute to akosbalasko/yarle developme
 
     Created at: 2020-10-17T16:07:59+01:00
     Updated at: 2020-10-17T16:07:59+01:00
+    Source URL: https://github.com/akosbalasko/yarle
 

--- a/test/data/test-webclip_screenshot.md
+++ b/test/data/test-webclip_screenshot.md
@@ -4,4 +4,5 @@
 
     Created at: 2020-10-17T16:08:28+01:00
     Updated at: 2020-10-17T16:08:28+01:00
+    Source URL: https://github.com/akosbalasko/yarle
 

--- a/test/data/test-webclip_simplifiedarticle.md
+++ b/test/data/test-webclip_simplifiedarticle.md
@@ -54,4 +54,5 @@ sharer.js, passport-evernote-auth, passport-evernote, share-buttons, _yarle_\-_e
 
     Created at: 2020-10-18T08:24:57+01:00
     Updated at: 2020-10-18T08:24:57+01:00
+    Source URL: https://www.google.com/search?sxsrf=ALeKk03bpXQ9mBvZPr4siq9b90rD9F_scA%3A1603005812287&ei=dO2LX9qUEcX1qwGn5brgBQ&q=yarle+evernote&oq=yarle+evernote&gs_lcp=CgZwc3ktYWIQAzIECCMQJzoHCCMQsAMQJzoHCAAQsAMQQzoHCC4QsAMQQzoJCAAQsAMQBxAeOgcIABCwAxAKOgUIABDJAzoCCAA6BAgAEAo6BAguEAo6BwguEMkDEA06BggAEA0QCjoGCAAQDRAeOggIABANEAoQHjoICAAQDRAFEB46CAgAEBYQChAeOgUIIRCgAToHCAAQyQMQDToECAAQDVDdEViJKmD_MGgDcAB4AYAB7gSIAf0RkgEJMC45LjEuNS0xmAEAoAEBqgEHZ3dzLXdpesgBCsABAQ&sclient=psy-ab&ved=0ahUKEwjano6Azr3sAhXF-ioKHaeyDlwQ4dUDCA0&uact=5
 

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -43,12 +43,12 @@ describe('SetFileDates', () => {
             notes['note']['updated'] = undefined;
             utils.setFileDates('./test/data/test-justText.enex', notes['note']);
             const fStat = fs.statSync('./test/data/test-justText.enex');
-            const atime = moment(fStat.atime).format();
-            const mtime = moment(fStat.mtime).format();
-            const referTime = moment();
-            assert.equal(atime, referTime.format());
-            assert.equal(mtime, referTime.format());
-
+            const atime = moment(fStat.atime);
+            const mtime = moment(fStat.mtime);
+            const referTimeLo = moment().subtract(3, 's');
+            const referTimeHi = moment().add(3, 's');
+            assert.ok(atime.isBetween(referTimeLo, referTimeHi));
+            assert.ok(mtime.isBetween(referTimeLo, referTimeHi));
     });
 
    });
@@ -126,7 +126,7 @@ describe('timestamps', () => {
                 },
         };
         const accessMoment = utils.getTimeStampMoment(resource);
-        assert.equal(accessMoment.isSame(moment(timestamp)), true);
+        assert.ok(accessMoment.isSame(moment(timestamp)));
     });
     it('no stored timstamp, return now', () => {
         const resource = {
@@ -134,7 +134,9 @@ describe('timestamps', () => {
             },
         };
         const accessMoment = utils.getTimeStampMoment(resource);
-        assert.equal(accessMoment.isSame(moment()), true);
+        const referTimeLo = moment().subtract(3, 's');
+        const referTimeHi = moment().add(3, 's');
+        assert.ok(accessMoment.isBetween(referTimeLo, referTimeHi));
     });
 });
 

--- a/test/yarle.spec.ts
+++ b/test/yarle.spec.ts
@@ -146,7 +146,7 @@ describe('dropTheRope ', async () => {
       fs.readFileSync(`${__dirname}/data/test-noteWithTags.md`, 'utf8'),
     );
   });
-  
+
   it('Note with notebook name', async () => {
     const options: YarleOptions = {
       enexSource: './test/data/test-noteWithNotebookName.enex',
@@ -169,7 +169,7 @@ describe('dropTheRope ', async () => {
       fs.readFileSync(`${__dirname}/data/test-noteWithNotebookName.md`, 'utf8'),
     );
   });
-  
+
   it('Note with notebook name and tags', async () => {
     const options: YarleOptions = {
       enexSource: './test/data/test-noteWithNotebookNameAndTags.enex',
@@ -287,6 +287,29 @@ describe('dropTheRope ', async () => {
     );
   });
 
+
+  it('Note with only source-url', async () => {
+    const options: YarleOptions = {
+      enexSource: './test/data/test-noteWithSourceUrl.enex',
+      outputDir: 'out',
+      isMetadataNeeded: true,
+    };
+    await yarle.dropTheRope(options);
+    assert.equal(
+      fs.existsSync(
+        `${__dirname}/../out/notes/test-noteWithSourceUrl/Test.md`,
+      ),
+      true,
+    );
+    assert.equal(
+      fs.readFileSync(
+        `${__dirname}/../out/notes/test-noteWithSourceUrl/Test.md`,
+        'utf8',
+      ),
+      fs.readFileSync(`${__dirname}/data/test-noteWithSourceUrl.md`, 'utf8'),
+    );
+  });
+
   it('Enex file with note containing a picture', async () => {
     const options: YarleOptions = {
       enexSource: './test/data/test-withPicture.enex',
@@ -357,7 +380,7 @@ describe('dropTheRope ', async () => {
       ),
       fs.readFileSync(`${__dirname}/data/test-note-with-picture.html`, 'utf8'),
     );
-    
+
   });
   it('Skips images without src attribute', async () => {
     const options: YarleOptions = {
@@ -544,7 +567,7 @@ describe('dropTheRope ', async () => {
       fs.readFileSync(`${__dirname}/data/test-skipLocation.md`, 'utf8'),
     );
   });
-  
+
   it('Enex file with two notes with same names', async () => {
     const options: YarleOptions = {
       enexSource: './test/data/test-twoNotesWithSameName.enex',
@@ -1224,7 +1247,7 @@ describe('dropTheRope ', async () => {
     await yarle.dropTheRope(options);
     const dirList = fs.readdirSync(`${__dirname}/../out/notes/test-case-sensitive/`);
     assert.equal(dirList.includes('TEST - templates just content.md'), true);
-    
+
     assert.equal(
       fs.readFileSync(
         `${__dirname}/../out/notes/test-case-sensitive/TEST - templates just content.md`,


### PR DESCRIPTION
In this case, xml-flow collapses the note-attribute sub-tag which will cause the corresponding note-attribute to be missing.

Fixed this edge-case and added a test spec "note with only source url". Without the change in `yarle.ts`, the test will fail.

Also added source-url to the default template, because I think the source URL is always important when there is one.