### PR TITLE
Do not only fix the first image in the HTML output

### DIFF
--- a/src/convert-to-html.ts
+++ b/src/convert-to-html.ts
@@ -15,7 +15,7 @@ export const convert2Html = (noteData: NoteData): void => {
   noteData.htmlContent = noteData.htmlContent.replace(/<(a href|img src)=".\/_resources\//, '<$1="./')
   */
 
-  noteData.htmlContent = `<div${m[1]}>${noteData.htmlContent.replace(/<(a href|img src)=".\/_resources\//, '<$1="./')}</div>`
+  noteData.htmlContent = `<div${m[1]}>${noteData.htmlContent.replace(/<(a href|img src)=".\/_resources\//g, '<$1="./')}</div>`
 
   let url = noteData.sourceUrl;
   if (url) {


### PR DESCRIPTION
The regex to fix the image sources in the HTML output should be a global one.