### PR TITLE
Support keeping image size

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ The following configurational properties are available:
 |```monospaceIsCodeBlock```| true or false | if it's true then all deepest elements with monospace font style is recognized as Codeblocks|    
 | ```dateFormat``` | string | ISO 8601 specification of the expected date format (e.g. YYYY-MM-DD)   
 |```keepMDCharactersOfENNotes```| true or false | set it true, if you used Markdown format in your EN notes|
-| ``` nestedTags``` | it's a complex property contains the following subitems: "separatorInEN", "replaceSeparatorWith" and  "replaceSpaceWith" | separatorInEN stores the tag separator used in Evernote, replaceSeparatorWith is the string to what separatorInEN should be replaced to, and replaceSpaceWith is the string to what the space character should be replaced to in the tags. For example using the default settings a tag ```tag1_sub tag of tag1``` is going to be converted to ```tag1/sub-tag-of-tag1``` 
-       
+| ```nestedTags``` | it's a complex property contains the following subitems: "separatorInEN", "replaceSeparatorWith" and  "replaceSpaceWith" | separatorInEN stores the tag separator used in Evernote, replaceSeparatorWith is the string to what separatorInEN should be replaced to, and replaceSpaceWith is the string to what the space character should be replaced to in the tags. For example using the default settings a tag ```tag1_sub tag of tag1``` is going to be converted to ```tag1/sub-tag-of-tag1```
+| ```keepObsidianImageSize``` | preserve an image's width and height in a format that is supported by Obsidian
+
 
 Metadata settings can be set via the template.
 

--- a/src/YarleOptions.ts
+++ b/src/YarleOptions.ts
@@ -24,4 +24,5 @@ export interface YarleOptions {
     monospaceIsCodeBlock?: boolean;
     dateFormat?: string;
     nestedTags?: TagSeparatorReplaceOptions;
+    keepObsidianImageSize?: boolean;
 }

--- a/src/process-resources.ts
+++ b/src/process-resources.ts
@@ -40,14 +40,21 @@ const addMediaReference = (content: string, resourceHashes: any, hash: any, rela
   const replace = `<en-media ([^>]*)hash="${hash}".([^>]*)>`;
   const re = new RegExp(replace, 'g');
   const matchedElements = content.match(re);
-  updatedContent = (matchedElements && matchedElements.length > 0 &&
-    matchedElements[0].split('type=').length > 1 &&
-    matchedElements[0].split('type=')[1].startsWith('"image')) ?
-    content.replace(re, `<img src="${src}" alt="${resourceHashes[hash].fileName}">`) :
-    content.replace(re, `<a href="${src}">${resourceHashes[hash].fileName}</a>`);
+
+  const mediaType = matchedElements && matchedElements.length > 0 && matchedElements[0].split('type=');
+  if (mediaType && mediaType.length > 1 && mediaType[1].startsWith('"image')) {
+    const width = matchedElements[0].match(/width="(\w+)"/);
+    const widthParam = width ? `width="${width[1]}"` : '';
+
+    const height = matchedElements[0].match(/height="(\w+)"/);
+    const heightParam = height ? `height="${height[1]}"` : '';
+
+    updatedContent = content.replace(re, `<img src="${src}" ${widthParam} ${heightParam} alt="${resourceHashes[hash].fileName}">`);
+  } else {
+    updatedContent = content.replace(re, `<a href="${src}">${resourceHashes[hash].fileName}</a>`);
+  }
 
   return updatedContent;
-
 };
 
 const processResource = (workDir: string, resource: any): any => {

--- a/src/process-resources.ts
+++ b/src/process-resources.ts
@@ -44,12 +44,12 @@ const addMediaReference = (content: string, resourceHashes: any, hash: any, rela
   const mediaType = matchedElements && matchedElements.length > 0 && matchedElements[0].split('type=');
   if (mediaType && mediaType.length > 1 && mediaType[1].startsWith('"image')) {
     const width = matchedElements[0].match(/width="(\w+)"/);
-    const widthParam = width ? `width="${width[1]}"` : '';
+    const widthParam = width ? ` width="${width[1]}"` : '';
 
     const height = matchedElements[0].match(/height="(\w+)"/);
-    const heightParam = height ? `height="${height[1]}"` : '';
+    const heightParam = height ? ` height="${height[1]}"` : '';
 
-    updatedContent = content.replace(re, `<img src="${src}" ${widthParam} ${heightParam} alt="${resourceHashes[hash].fileName}">`);
+    updatedContent = content.replace(re, `<img src="${src}"${widthParam}${heightParam} alt="${resourceHashes[hash].fileName}">`);
   } else {
     updatedContent = content.replace(re, `<a href="${src}">${resourceHashes[hash].fileName}</a>`);
   }

--- a/src/utils/turndown-rules/images-rule.ts
+++ b/src/utils/turndown-rules/images-rule.ts
@@ -14,8 +14,13 @@ export const imagesRule = {
     }
     const value = nodeProxy.src.value;
 
-    if (yarleOptions.outputFormat === OutputFormat.ObsidianMD &&
-        !value.match(/^[a-z]+:/)) {
+    const useObsidianMD = yarleOptions.outputFormat === OutputFormat.ObsidianMD;
+
+    if (useObsidianMD && yarleOptions.keepObsidianImageSize) {
+      return `![|${node.width}x${node.height}](${value})`;
+    }
+
+    if (useObsidianMD && !value.match(/^[a-z]+:/)) {
       return `![[${value}]]`;
     }
 


### PR DESCRIPTION
I added support to preserve an image's width and height on converted notes.

One option was to use raw HTML and keep the parameters, but it didn't feel right to use HTML in markdown. 
Thankfully Obsidian supports specifying an image's size by using the regular markdown image notation with a small twist, [e.g. here](https://forum.obsidian.md/t/0-9-7-resized-image-size-is-not-absolute/7728).
I also added a flag to enable this `keepObsidianImageSize`.

Hope this is useful to more people 😄 