### PR TITLE
feat: support having enex-level resource folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ To configure Yarle, you must create a config file. By default it looks like this
     "useHashTags": true,
     "outputFormat": "StandardMD",
     "skipEnexFileNameFromOutputPath": false,
+    "haveEnexLevelResources": false,
     "monospaceIsCodeBlock": false,
     "keepMDCharactersOfENNotes": false,
     "nestedTags": {
@@ -73,11 +74,12 @@ The following configurational properties are available:
 |```plaintextNotesOnly``` |  true or false | skips any notes with attachments (e.g. notes containing pictures)|
 |```useHashTags```|  true or false | whether to add the pound sign in front of tags|
 |```outputFormat```|  true or false | generates internal file links and highlights in Obsidian-style: highlights are going to be bounded by `==` instead of \` characters, file links are going to be as follows: `![[file-name]]` instead of `![file-name](file-name)`. Possible values: `ObsidianMD` to get Obsidian-style notes, `StandardMD` or skip it completely, if you prefer Standard Markdown format.|
-|```monospaceIsCodeBlock```| true or false | if it's true then all deepest elements with monospace font style is recognized as Codeblocks|    
-| ```dateFormat``` | string | ISO 8601 specification of the expected date format (e.g. YYYY-MM-DD)   
+|```haveEnexLevelResources```|  true or false | stores note resources on global _resources folder per enex export if enabled |
+|```monospaceIsCodeBlock```| true or false | if it's true then all deepest elements with monospace font style is recognized as Codeblocks|
+| ```dateFormat``` | string | ISO 8601 specification of the expected date format (e.g. YYYY-MM-DD)
 |```keepMDCharactersOfENNotes```| true or false | set it true, if you used Markdown format in your EN notes|
-| ``` nestedTags``` | it's a complex property contains the following subitems: "separatorInEN", "replaceSeparatorWith" and  "replaceSpaceWith" | separatorInEN stores the tag separator used in Evernote, replaceSeparatorWith is the string to what separatorInEN should be replaced to, and replaceSpaceWith is the string to what the space character should be replaced to in the tags. For example using the default settings a tag ```tag1_sub tag of tag1``` is going to be converted to ```tag1/sub-tag-of-tag1``` 
-       
+| ``` nestedTags``` | it's a complex property contains the following subitems: "separatorInEN", "replaceSeparatorWith" and  "replaceSpaceWith" | separatorInEN stores the tag separator used in Evernote, replaceSeparatorWith is the string to what separatorInEN should be replaced to, and replaceSpaceWith is the string to what the space character should be replaced to in the tags. For example using the default settings a tag ```tag1_sub tag of tag1``` is going to be converted to ```tag1/sub-tag-of-tag1```
+
 
 Metadata settings can be set via the template.
 

--- a/src/YarleOptions.ts
+++ b/src/YarleOptions.ts
@@ -1,5 +1,5 @@
 import { OutputFormat } from './output-format';
-import { TagSeparatorReplaceOptions } from 'models';
+import { TagSeparatorReplaceOptions } from './models';
 
 export interface YarleOptions {
     enexSource?: string;
@@ -20,6 +20,7 @@ export interface YarleOptions {
     useHashTags?: boolean;
     outputFormat?: OutputFormat;
     skipEnexFileNameFromOutputPath?: boolean;
+    haveEnexLevelResources?: boolean;
     keepMDCharactersOfENNotes?: boolean;
     monospaceIsCodeBlock?: boolean;
     dateFormat?: string;

--- a/src/process-resources.ts
+++ b/src/process-resources.ts
@@ -9,8 +9,8 @@ export const processResources = (note: any): string => {
     let resourceHashes: any = {};
     let updatedContent = cloneDeep(note.content);
 
-    const relativeResourceWorkDir = `${utils.getResourceDir(utils.paths.mdPath, note)}.resources`;
-    const absoluteResourceWorkDir = `${utils.paths.resourcePath}/${relativeResourceWorkDir}`;
+    const relativeResourceWorkDir = utils.getRelativeResourceDir(note);
+    const absoluteResourceWorkDir = utils.getAbsoluteResourceDir(note);
 
     utils.clearResourceDir(note);
     if (Array.isArray(note.resource)) {
@@ -20,7 +20,6 @@ export const processResources = (note: any): string => {
           ...processResource(absoluteResourceWorkDir, resource)};
       }
     } else {
-      utils.clearResourceDir(note);
       resourceHashes = {
         ...resourceHashes,
         ...processResource(absoluteResourceWorkDir, note.resource)};
@@ -33,9 +32,9 @@ export const processResources = (note: any): string => {
     return updatedContent;
   };
 
-const addMediaReference = (content: string, resourceHashes: any, hash: any, relativeResourceWorkDir: string): string => {
+const addMediaReference = (content: string, resourceHashes: any, hash: any, workDir: string): string => {
+  const src = `${workDir}/${resourceHashes[hash].fileName.replace(/ /g, '\ ')}`;
 
-  const src = `./_resources/${relativeResourceWorkDir}/${resourceHashes[hash].fileName.replace(/ /g, '\ ')}`;
   let updatedContent = cloneDeep(content);
   const replace = `<en-media ([^>]*)hash="${hash}".([^>]*)>`;
   const re = new RegExp(replace, 'g');
@@ -64,7 +63,6 @@ const processResource = (workDir: string, resource: any): any => {
     const atime = accessTime.valueOf() / 1000;
     fs.utimesSync(absFilePath, atime, atime);
 
-    // tslint:disable-next-line: curly
     if (resource.recognition && fileName) {
       const hashIndex = resource.recognition.match(/[a-f0-9]{32}/);
       resourceHash[hashIndex as any] = {fileName, alreadyUsed: false} as ResourceHashItem;

--- a/src/utils/folder-utils.ts
+++ b/src/utils/folder-utils.ts
@@ -31,18 +31,36 @@ export const getHtmlFileLink = (note: any): string => {
 };
 
 const clearDistDir = (dstPath: string): void => {
-    if (fs.existsSync(dstPath)) {
-        fsExtra.removeSync(dstPath);
-    }
-    fs.mkdirSync(dstPath);
+  if (fs.existsSync(dstPath)) {
+    fsExtra.removeSync(dstPath);
+  }
+  fs.mkdirSync(dstPath);
 };
 
+export const getRelativeResourceDir = (note: any): string => {
+  return yarleOptions.haveEnexLevelResources ? './_resources' : `./_resources/${getResourceDir(paths.mdPath, note)}.resources`;
+};
+
+export const getAbsoluteResourceDir = (note: any): string => {
+  return yarleOptions.haveEnexLevelResources ? paths.resourcePath : `${paths.resourcePath}/${getResourceDir(paths.mdPath, note)}.resources`;
+};
+
+const resourceDirClears = new Map<string, number>();
 export const clearResourceDir = (note: any): void => {
+  const path = getAbsoluteResourceDir(note);
+  if (!resourceDirClears.has(path)) {
+    resourceDirClears.set(path, 0);
+  }
 
-  const relativeWorkDir = `${getResourceDir(paths.mdPath, note)}.resources`;
-  const absoluteWorkDir = `${paths.resourcePath}/${relativeWorkDir}`;
+  const clears = resourceDirClears.get(path);
 
-  clearDistDir(absoluteWorkDir);
+  // we're sharing a resource dir, so we can can't clean it more than once
+  if (yarleOptions.haveEnexLevelResources && clears >= 1) {
+    return;
+  }
+
+  clearDistDir(path);
+  resourceDirClears.set(path, clears + 1);
 };
 
 export const clearResourceDistDir = (): void => {
@@ -53,9 +71,8 @@ export const clearMdNotesDistDir = (): void => {
 };
 
 export const setPaths = (): void => {
-
   const enexFolder = yarleOptions.enexSource.split('/');
-  const enexFile = (enexFolder.length >= 1 ?  enexFolder[enexFolder.length - 1] : enexFolder[0]).split('.')[0];
+  const enexFile = (enexFolder.length >= 1 ? enexFolder[enexFolder.length - 1] : enexFolder[0]).split('.')[0];
 
   paths.mdPath = `${process.cwd()}/${yarleOptions.outputDir}/notes/`;
   paths.resourcePath = `${process.cwd()}/${yarleOptions.outputDir}/notes/_resources`;
@@ -67,5 +84,4 @@ export const setPaths = (): void => {
   fsExtra.mkdirsSync(paths.resourcePath);
   // clearDistDir(paths.simpleMdPath);
   // clearDistDir(paths.complexMdPath);
-
 };


### PR DESCRIPTION
I added a `haveEnexLevelResources` option, so resources for a given enex
can be stored on the same folder, as mentioned on https://github.com/akosbalasko/yarle/issues/164.

To make this work, I had to count resource folder clears, so as ensure
the global enex-level resource folder isn't systematically deleted each time a note's
resources are processed.