### PR TITLE
feat: add `resourcesDir` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The following configurational properties are available:
 |```enexSource```| your enex file or the folder of your enex files | specifies the exported Evernote notebook(s) as an absolute path|
 |```templateFile``` | path of your custom template file | if its not specified, a [default template](https://github.com/akosbalasko/yarle/blob/master/src/utils/templates/default-template.ts) will be used
 |```outputDir``` | path to your output dir (absolute or relative) | this is the main output dir where the extracted markdown files and the external resources, images, pdf-s are going to be created|
+|```resourcesDir``` | `_resources` | subdir where attachments/external resources will be placed
 |```isZettelkastenNeeded``` |  true or false | puts Zettelkasten Id (based on time of creation) at the beginning of the file name|
 |```plaintextNotesOnly``` |  true or false | skips any notes with attachments (e.g. notes containing pictures)|
 |```useHashTags```|  true or false | whether to add the pound sign in front of tags|

--- a/src/YarleOptions.ts
+++ b/src/YarleOptions.ts
@@ -30,4 +30,5 @@ export interface YarleOptions {
     keepOriginalAmountOfNewlines?: boolean;
     addExtensionToInternalLinks?: boolean;
     pathSeparator?: string;
+    resourcesDir?: string;
 }

--- a/src/utils/folder-utils.ts
+++ b/src/utils/folder-utils.ts
@@ -40,7 +40,7 @@ const clearDistDir = (dstPath: string): void => {
 };
 
 export const getRelativeResourceDir = (note: any): string => {
-  return yarleOptions.haveEnexLevelResources ? `.${path.sep}_resources` : `.${path.sep}_resources${path.sep}${getResourceDir(paths.mdPath, note)}.resources`;
+  return yarleOptions.haveEnexLevelResources ? `.${path.sep}${yarleOptions.resourcesDir}` : `.${path.sep}${yarleOptions.resourcesDir}${path.sep}${getResourceDir(paths.mdPath, note)}.resources`;
 };
 
 export const getAbsoluteResourceDir = (note: any): string => {
@@ -84,13 +84,13 @@ export const setPaths = (): void => {
     : `${process.cwd()}${path.sep}${yarleOptions.outputDir}`;
 
   paths.mdPath = `${outputDir}${path.sep}notes${path.sep}`;
-  paths.resourcePath = `${outputDir}${path.sep}notes${path.sep}_resources`;
+  paths.resourcePath = `${outputDir}${path.sep}notes${path.sep}${yarleOptions.resourcesDir}`;
   // loggerInfo(`Skip enex filename from output? ${yarleOptions.skipEnexFileNameFromOutputPath}`);
   if (!yarleOptions.skipEnexFileNameFromOutputPath) {
     paths.mdPath = `${paths.mdPath}${enexFile}`;
     // loggerInfo(`mdPath: ${paths.mdPath}`);
 
-    paths.resourcePath = `${outputDir}${path.sep}notes${path.sep}${enexFile}${path.sep}_resources`;
+    paths.resourcePath = `${outputDir}${path.sep}notes${path.sep}${enexFile}${path.sep}${yarleOptions.resourcesDir}`;
   }
   fsExtra.mkdirsSync(paths.mdPath);
   fsExtra.mkdirsSync(paths.resourcePath);

--- a/src/yarle.ts
+++ b/src/yarle.ts
@@ -29,7 +29,8 @@ export const defaultYarleOptions: YarleOptions = {
   },
   outputFormat: OutputFormat.StandardMD,
   urlEncodeFileNamesAndLinks: false,
-  pathSeparator: '/'
+  pathSeparator: '/',
+  resourcesDir: '_resources',
 };
 
 export let yarleOptions: YarleOptions = { ...defaultYarleOptions };

--- a/test/data/test-withPicture-customResourcesDir.md
+++ b/test/data/test-withPicture-customResourcesDir.md
@@ -1,0 +1,8 @@
+# test - note with picture
+
+This is the content
+![pic.jpeg](./_attachments/test_-_note_with_picture.resources/pic.jpeg)
+
+    Created at: 2018-10-06T09:44:14+01:00
+    Updated at: 2018-10-06T09:46:10+01:00
+

--- a/test/yarle-special-cases.spec.ts
+++ b/test/yarle-special-cases.spec.ts
@@ -70,6 +70,38 @@ describe('Yarle special cases', async () => {
       fs.readFileSync(`${__dirname}/data/test-withPicture.md`, 'utf8'),
     );
   });
+
+  it('Override resourcesDir', async () => {
+    const options: YarleOptions = {
+      enexSource: `.${path.sep}test${path.sep}data${path.sep}test-withPicture.enex`,
+      outputDir: 'out',
+      resourcesDir: '_attachments',
+      isMetadataNeeded: true,
+    };
+    await yarle.dropTheRope(options);
+    console.log(`conversion log: ${fs.readFileSync(LOGFILE)}`);
+    assert.equal(
+      fs.existsSync(
+        `${__dirname}/../out/notes/test-withPicture/test - note with picture.md`,
+      ),
+      true,
+    );
+    assert.equal(
+      fs.existsSync(
+        `${__dirname}/../out/notes/test-withPicture/_attachments/test_-_note_with_picture.resources`,
+      ),
+      true,
+    );
+
+    assert.equal(
+      eol.auto(fs.readFileSync(
+        `${__dirname}/../out/notes/test-withPicture/test - note with picture.md`,
+        'utf8',
+      )),
+      fs.readFileSync(`${__dirname}/data/test-withPicture-customResourcesDir.md`, 'utf8'),
+    );
+  });
+
   it.skip('should keep Html content', async () => {
 
     const options: YarleOptions = {


### PR DESCRIPTION
Allow customizing subdir for attachments (default `_resources`).

This PR adds (and documents and tests) a new `resourcesDir` config option to permit using a directory like `_attachments` rather than `_resources`.

(The PR does not expose the new option in the Electron UI.)
