### PR TITLE
fix: convert strikethrough using `~~` rather than `~`

### DIFF
--- a/src/utils/turndown-rules/index.ts
+++ b/src/utils/turndown-rules/index.ts
@@ -3,5 +3,6 @@ export * from './monospace-code-block-rule';
 export * from './images-rule';
 export * from './internal-links-rule';
 export * from './span-rule';
+export * from './strikethrough-rule';
 export * from './task-items-rule';
 export * from './newline-rule';

--- a/src/utils/turndown-rules/strikethrough-rule.ts
+++ b/src/utils/turndown-rules/strikethrough-rule.ts
@@ -1,0 +1,8 @@
+// Note: this rule must appear *after* use(gfm) so it can override
+// turndown-plugin-gfm rule for strikethrough (which always uses single '~')
+export const strikethroughRule = {
+  filter: ['del', 's', 'strike'],
+  replacement: (content: any) => {
+    return `~~${content}~~`;
+  },
+};

--- a/src/utils/turndown-service.ts
+++ b/src/utils/turndown-service.ts
@@ -2,7 +2,7 @@ import TurndownService from 'turndown';
 import { gfm } from 'joplin-turndown-plugin-gfm';
 import { YarleOptions } from './../YarleOptions';
 
-import { monospaceCodeBlockRule, newLineRule, codeBlockRule, imagesRule, spanRule, taskItemsRule, wikiStyleLinksRule } from './turndown-rules';
+import { monospaceCodeBlockRule, newLineRule, codeBlockRule, imagesRule, spanRule, strikethroughRule, taskItemsRule, wikiStyleLinksRule } from './turndown-rules';
 
 /* istanbul ignore next */
 const turndownService = new TurndownService({
@@ -19,6 +19,7 @@ const turndownService = new TurndownService({
     });
 turndownService.use(gfm);
 turndownService.addRule('span', spanRule);
+turndownService.addRule('strikethrough', strikethroughRule);
 turndownService.addRule('evernote task items', taskItemsRule);
 turndownService.addRule('wikistyle links', wikiStyleLinksRule);
 turndownService.addRule('images', imagesRule);

--- a/test/data/test-strikethrough.enex
+++ b/test/data/test-strikethrough.enex
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export4.dtd">
+<en-export export-date="20210815T220111Z" application="Evernote" version="10.17.6">
+  <note>
+    <title>test - strikethrough</title>
+    <created>20210715T220030Z</created>
+    <updated>20210715T220054Z</updated>
+    <note-attributes>
+    </note-attributes>
+    <content>
+      <![CDATA[<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div>Normal <s>strikethrough</s> normal</div></en-note>      ]]>
+    </content>
+  </note>
+</en-export>

--- a/test/data/test-strikethrough.md
+++ b/test/data/test-strikethrough.md
@@ -1,0 +1,7 @@
+# test - strikethrough
+
+Normal ~~strikethrough~~ normal
+
+    Created at: 2021-07-15T23:00:30+01:00
+    Updated at: 2021-07-15T23:00:54+01:00
+

--- a/test/yarle-tests.ts
+++ b/test/yarle-tests.ts
@@ -414,6 +414,17 @@ export const yarleTests: Array<YarleTest> = [
     expectedOutputPath: `${dataFolder}test-nospanstyle.md`,
   },
 
+  {
+    name: 'Note with strikethrough',
+    options: {
+      enexSource: `.${testDataFolder}test-strikethrough.enex`,
+      outputDir: 'out',
+      isMetadataNeeded: true,
+    },
+    testOutputPath: `notes${path.sep}test-strikethrough${path.sep}test - strikethrough.md`,
+
+    expectedOutputPath: `${dataFolder}test-strikethrough.md`,
+  },
 
   {
     name: 'Note with sublists',


### PR DESCRIPTION
Convert EN `<s>strike</s>` to `~~strike~~` rather than `~strike~`,
for compatibility with Obsidian and Joplin. (GFM allows either.)

Fixes #282