### PR TITLE
fix: extract resources from data urls

### DIFF
--- a/src/process-node.ts
+++ b/src/process-node.ts
@@ -7,7 +7,7 @@ import {
   saveMdFile,
 } from './utils';
 import { yarleOptions } from './yarle';
-import { processResources } from './process-resources';
+import { extractDataUrlResources, processResources } from './process-resources';
 import { convertHtml2Md } from './convert-html-to-md';
 import { convert2Html } from './convert-to-html';
 import { NoteData } from './models/NoteData';
@@ -36,6 +36,7 @@ export const processNode = (note: any, notebookName: string): void => {
     if (isComplex(note)) {
       noteData.htmlContent = processResources(note);
     }
+    noteData.htmlContent = extractDataUrlResources(note, noteData.htmlContent);
 
     noteData = {...noteData, ...convertHtml2Md(yarleOptions, noteData)};
     noteData = {...noteData, ...getMetadata(note, notebookName)};

--- a/test/data/test-image-dataUrl.enex
+++ b/test/data/test-image-dataUrl.enex
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export4.dtd">
+<en-export export-date="20210817T223419Z" application="Evernote" version="10.17.6">
+  <note>
+    <title>test - image - dataUrl</title>
+    <created>20210717T173545Z</created>
+    <updated>20210717T223356Z</updated>
+    <note-attributes>
+      <source>web.clip7</source>
+      <source-url>https://unsplash.com/photos/3ym6i13Y9LU</source-url>
+      <source-application>webclipper.evernote</source-application>
+    </note-attributes>
+    <content>
+      <![CDATA[<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div><br /></div><img style="--en-naturalWidth:24; --en-naturalHeight:16;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAQCAYAAAAMJL+VAAAE9klEQVQ4EUWSaWxUZRiF7x8SYiJE0NJFWmCgtCydQmFaKFjtANIKUkpBdlqxVMFGjCxiNEGM
+G8aFshRITBBxCQJqiAgSwER2CIWWlgLTmbmz9O537nQ6pS0tj+k16o8n33n/fCfvOa+wJiuZBSOfYNbYFHJHJVGQOYLckUMZnzaIzKT+OJP6kZv2GEUTUnCP
+TSDf8TjPZQ62meIYyPTMFKZlplE4Lp1ip4PFOSmsyU9l9VQHK10jEJZlDGKuYyAznUOpfKmY6uULeXXpfMoXz2ZFmZtXlxWxurSA8hfzmZOfQZk729ZVCwtZ
+XVbIitJZLC8pYlXJHKoXz2NNUQ5V7nQ2zZ3Im7MyERY5E5iRPoANVQuQQw20qT4iqhdVu4ukNmEYLRial1g0RGvojk3UFOmMy8TbFSIxDTOqEzEU6Ilx7Jsv
+WVQwgk3zMnh37giEhZOTeG7MQD7Ztg4r5kcUGxCDjfikepuQfB9JCxLviqJbkq2NqEIfrXoQvd1Ai5nImswjOjl0cCeFk5P4qNzFx4tGI7yQ9QR5jv7U1Gwh
+8iDAPd9NPP5bNIdv0ByoQ1FFdDlMu2WghEXCohdTlWgzNQxNQjdbiVgKshQEHrJn7xe4xiby3tI8tpaMRpjjHMSkYf3Ys/s9zA6RoNSM2HoHj1yPp7UBVRUx
+pTAdEQM1JCL5vViqRMzQbCNLD2FFpP8N9u3AmZnE2uJxvDZ9CML8rMHkJAt8XbuVSJsPj6cOr1iPX25AVG6jaD50OUh7VEMJ+wiLHkwtTJupYOjh/zaQpLC9
+we7az8kek8grRVlUFqQhlGY/SXaCwMH9HxCxWlAUj93Bzea/uHjjlG2gKkFiUQ2p1Ucw4KFvtiIK2r8GEY2wHKaXh9TUbseZ+RSr3OmUT01CmD8xgawhAod/
++BI92oI/0GDH5FNv8+nOrbz/4Tt0dceJxy0CQS9+vwdZDqHpErohY0U0LNNAVWWgm/3f7mJanoOKmQ42FY9EWORKtks+cngHRsyHpLfYHQT0JnxKE6+vr6Si
+YoX9qRXVudPcgKKGaYuZmKZin2fUUFCVvoi6qNn3GTMKMqguTmdbySiEVdOGU5yTyPGje+wOAoFGJOWe3UFAbSQWV/jmwD4qypdw+eKfdjx92StyAF0LEDXC
+NoYasg3e2byOWa5Utr/s4rvqKQiVz6azZPpIfv95L9E2P0F/AyGxEcm4izd8C9nw0tMb5dKVM7y2bhUnTh5BM0Q6OnXMSBDLCttXpNsG3WzZsJbnXcPZ/9Yc
+vt/oRigbP5jSSU9z6kgtUrAe8V4d/vt1eFqu4Q3VcS9QR6PvBu2PDK43nqd68xrOXjpBq+XDE2xE1QPISoCALNLRE+ermu3MdefyxYZl/PhxFcKS8QksyE7m
+6snvoMeg0wzZxKN+Oh4EiHeG6HlkEH/QSudDFdPyoej36e7V6erR6O7W6e2NYrb1ldzFTz8eYOq4VHa8vZKa9aUIK5yJLMhKZPf7b3D2+CFOHf2HE78c4PRv
+B7l67hj1F36n+eoZrpw+xvVzv9J0+Q+unf2FWxd/48b5X6m7dJxrF44jNl2idttG5k9M46PleeyqzEWomJBM2bghTMtIoGDSKFwZabjGDGPC2BTynKnMnJxO
+4fhhuJ3DmZ3zj+57S/KzKM4bzTPOIczIS6O4YAwzcxy4RyVQVZDBlqJU3nYP4G/iKFGyEABz6gAAAABJRU5ErkJggg==" /><div><img style="--en-naturalWidth:16; --en-naturalHeight:16;" src="data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' class='_18nzi js-evernote-checked' viewBox='0 0 32 32' version='1.1' aria-hidden='false' data-evernote-id='382'%3e%3cpath d='M16 0c-8.8 0-16 7.2-16 16s7.2 16 16 16 16-7.2 16-16-7.2-16-16-16zm2 25c0 .6-.4 1-1 1h-2c-.6 0-1-.4-1-1v-12c0-.6.4-1 1-1h2c.6 0 1 .4 1 1v12zm0-16c0 .6-.4 1-1 1h-2c-.6 0-1-.4-1-1v-2c0-.6.4-1 1-1h2c.6 0 1 .4 1 1v2z' data-evernote-id='382' class='js-evernote-checked'%3e%3c/path%3e%3c/svg%3e" /> Photo by <a href="https://unsplash.com/@m15ky">Mike Tinnion</a></div><img style="--en-naturalWidth:16; --en-naturalHeight:16;" src="data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' class='_18nzi js-evernote-checked' viewBox='0 0 32 32' version='1.1' aria-hidden='false' data-evernote-id='382'%3e%3cpath d='M13.3333 18.9333l8.8-8.8L24 12 13.3333 22.6667 8 17.3333l1.86667-1.8666 3.46663 3.4666zM28 6.66668v8.00002c0 7.3333-5.0667 14.2666-12 16-6.93333-1.7334-12-8.6667-12-16V6.66668l12-5.33334 12 5.33334zm-2.6667 1.73333L16 4.26668 6.66667 8.40001v6.26669c0 6 4.00003 11.6 9.33333 13.2 5.3333-1.6 9.3333-7.2 9.3333-13.2V8.40001z' data-evernote-id='383' class='js-evernote-checked'%3e%3c/path%3e%3c/svg%3e" /><div><a href="https://unsplash.com/license" rev="en_rl_none">Free to use under the Unsplash License</a></div><div><br /></div><en-media style="--en-naturalWidth:60; --en-naturalHeight:41;" hash="64c11ef139c91b3826da3b5a4989a9ca" type="image/png" /><div><br /></div><div><br /></div><img style="--en-naturalWidth:16; --en-naturalHeight:16;" src="data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' class='_18nzi js-evernote-checked' viewBox='0 0 32 32' version='1.1' aria-hidden='false' data-evernote-id='382'%3e%3cpath d='M13.3333 18.9333l8.8-8.8L24 12 13.3333 22.6667 8 17.3333l1.86667-1.8666 3.46663 3.4666zM28 6.66668v8.00002c0 7.3333-5.0667 14.2666-12 16-6.93333-1.7334-12-8.6667-12-16V6.66668l12-5.33334 12 5.33334zm-2.6667 1.73333L16 4.26668 6.66667 8.40001v6.26669c0 6 4.00003 11.6 9.33333 13.2 5.3333-1.6 9.3333-7.2 9.3333-13.2V8.40001z' data-evernote-id='384' class='js-evernote-checked'%3e%3c/path%3e%3c/svg%3e" /></en-note>      ]]>
+    </content>
+    <resource>
+      <data encoding="base64">
+        iVBORw0KGgoAAAANSUhEUgAAADwAAAApCAYAAABp50paAAAUoklEQVRoBdWad3jUVbrHfyjS03shvUwyyWRCem+kh/RGCKH3IiKgomJHEI0LKooXUSyr69q9
+        6y4W3N27si6414IJENInk0kyyWRCQFSEz33OCcFQdp/18bl7vX98n3N+bZLvedt53/coeUEuZAY4kOBrRbTXNOK9LUn0sSLDx5ZsP1vyghzIVdtRoLanUO1A
+        aagTZRpniYowV6oi3SjWOpIXYkt2kCVJ3hNI9LqBlIAp5ITaUhLuTHm4CxURzhKzY1yojnakItKWinBr5se5URvpyJwIB+qinFiS6MHCeHfmx7gyL9qFhYlu
+        zI93kajUWlMTaUdVuI0c50c7sSjcnjqNDZURVpRH2FCmtaYkzIbccGtywm3JD7MnP9SOvBAxOqAUqp3IDXYgXWVDcqCVHNP8rUj3tiDDcyoZPpZk+VuTq7Jj
+        VogT5eHTKdO6SxSHuVKkdSZP40BWsA0zVVYSGQHWZKsdKIlwozrWkzlxHhJzEz0QqE1woybWhZoYJxYlejE32o2aCCfmRDpTF+suIe7VRrlQF+tKbbQTFWHW
+        1EQ4MCfKUWJBvDsr0/24OUfNyhQflqR7sKYgiDlx7lRGu1IYaS9JF2rtqIx2py7ZjwWpQSgVWkdKtfYUhdsjHhaE25GvsSFPbUW+yoqCIAcKVE4UBDszS+1C
+        cbgHBaGuZKudyAiyJ9HPRmqH0IwEb0uyg13IUblSGOJBZZQP8xK9mRvnSnWkA2VhttTGuDE7ypWqGc5UhrtQqrGjJMQW8X/UCOIXURsznbmxHixM8GZhgqck
+        L8YF8eKeJ8vT/FmTo2FlThjLs9SszPJjRU4AS7JDWZAZzPwMH+alejEv1YeFqf4sSgtgYUogSlWEI1VRTlRHO1MZ40xJpAOlUY5UxrlQFedJdVwApVG+zNJ6
+        kh3iSpbajTSVEwk+NkR7WhLieAMhjhPROE0izHESMxwnE+4wiRiXaaT4jEg9O8RKqtascGdyQhzlYmWqHElXOZAR5EhagL2ci98X1zODnckJdSM3zJWcEGfy
+        Qp0onOF+8VsHMoNspQYVhLmRo3WlKimA2kQPCjXWlMZ5UpPsz7JMf9bmB7E2T83ymYEsSvahLn46SnWUBxUz3CnROEk7zQy0IiPQkrRgKxICLAlyvgF/hwkS
+        QU6TUbtOJtRlBGHOkxHQukwj3NWCMLepBDlNxNtKwXmCgvU4hYmKwuRxChY3KFhNUJggrhUFi+tHMF5RsJqoMN1hGk5WE3Czn4qHowXO1hOZOn7kffEbjhYK
+        4t0p40a+F78x6SICHa6TpijstSrZj+pEb9ZmB7Ey3YsN+WpWZ6lYJiSdOB2lMNRZ2qZwTtkqW7KC7aQtZ0Q4U10QxTO772f/3nqe31vPM7u38ezuB3n+yW3s
+        3/0gL+7exktPbOPXux/ilSd38PKeh/ntc7t47YXHeePXu3nzN3t4Yf9O9uzZzo4dd3LvvRsoKc6U2LRxNQ/veID777+bX+18mH3PPs1zz/0HL7z4rMTeZ56S
+        9+sf3cZjj+/giScf4dGdD7Lrse3yevdT9ex56hH27X2E117cxfbNy6lMDaEuM4il2UFsnBXKLXlBbC7WcGuxhs2lYXJUCrQuCBSGuZCvcSZVbUvdrAi23rWQ
+        Dw88y7ffGRga1kuc/c6I+VSXhMncgUC/qRPTQCfmizg1qGfY3M2Z4R6+PdPHhQvDwFngGzmePdtPZ2cDZrOO778zwYVvgR84f+7sJVw4/x1wjgt8z/kL4ttz
+        nEfc+17iB77lHGf5/odTXMDM+fMDcOEMrz3zCDUp3izP9GZNui83Z6nYkBfAzbn+chRzJTvAipxAa/KCbchW2xHnN5WSjGDu27KQr77+A60dX9CmOyZxsvNr
+        RnG88ygCTR1HaWpvoKWjcQRtDXR0nqDH0Eq/sZO+vg5MA90MDxk5c9pIT08TzS1/p6npsCQu3hswGugx6Bgc6MXU3yOvxWgaNGDs12Mw6jCauiXEXKBvQE+f
+        SUf/UAeDp/Vy4d55ZR+12RpuKg1nXU4wW0pmsKVcy62FKtbn+LA63R2lLsKZedFuLEhwZV6SJ+UxvkR6WfJE/UZaWz9B130Unf6YRLu+EYG2robLoTtGZ9fx
+        S9DpT2DoaabX2EZffzumQT2nhvs5800/RlMLJ1uPyIUUv6s3tNBn7KLf1M2guVeSFET/FfSb9ZiGu+gztXGOMzy/fw/erhYUJgVz5+xk7i6LYEu5hi3lIdxR
+        FsxtxYEoa1P9WCGCfaw9VRH20hvH+trx0r4HJGG9/kfCnV2NCHToGq7C6DMxCiKG3iZ6jS3/AuGT9PV30m/qYtAsiOqvwD8jLwh30zPYIQk/+8Ierr9BITbU
+        g42lMdxTquXuilC2VARzV6VaQqkMtqZSbUmFZioloZYyJCQGu/HBe/toaf4LYwkLImOJjSU/9v7/BeEf+IZ9zz/JxEnjSIn0Z0ttCvXz4tlaE8E91WHcVREq
+        pazMjZ4uVXp+rLPcpST52ZOo8ebIJ29zsuUQuu6GSyr9SyQ8MKTHYGrnPGd55rmnsLCcSFq0ijvnJLG9JpqH6mLZWhvN/XOiuK8mAqVM40hxkDVlwRaUaZ0J
+        dZlKakwwDV8dpLn1b3QZGukyHJcQhK9Feqx0xfznSFio9eXolbYt7PtqGOg36yRh+Jan9+1GGacwI9CNdYURbM4PYnOhmtuK1NxeEsrm4hCU0jBnioJtKQu2
+        okzrirf1eDJTI2k4+ieaW478wgn3Yhzsoru/Q4arp/Y+zoSJ1xGj9mRxeiBrkt1lLF6XGcDqNB+WJXmgiARgVrA9ZcE2lIS7YjteoaggncbGQzS1HL6MsJD0
+        qJRHxyul+++V8FjC59i9ZyfjrlNI1PqxLDOI23KDZCxenebHiiRvFse5oxRrRVJgS6kgrHVniqJQXZnLsWOfcKL50/9HhL/niad+hb2DNQWpkZLwLTkqViZ5
+        SrKrUn0RUMpD7ajQ2DMnwl2miWJ/unT+LBq+/kg6rbE2PGrLQooiNLV3Hr0qPAnJi/d6+prp62/FONAhbXL4zADfnDXRP9hKc9tntHd+Kd8TsVqEJAERki63
+        X2HP17LdH++JWKw3tkuVFoSvH6+QGRcqs6MbU72khG/KCmLdTBVr0v1RSlQWUrqVWjfiPaZgoSisWVLC8YaPaG27XMKjZH6JhMXW87EnH5UqnRGjZkGKH2uS
+        PeQeY2mCB0vip4+otEi6Re4pkuM4zynYXKewYU0ljY0f0NZ+tZcW0vulEt61ux5FUUiJCGRugherEtxYFO3M/CiXS1AqtPZURbowJymQIBsFhwkKt62fLQl3
+        6H700qNO6pdGeGDIcEmldz7+qCScFO4vKyzLYp1ZHOPColg3KV0hZaVYYymrHXlaN3wtFLysFO5YX8OJxg8vSVjfc+KyWCzst7XjK062fE7jicO8/e5LvP/R
+        G/z1bx9cFoP7B9tHsqlBPeahPk6d7mNgoEWGu/b2L9DLvfTlW8ufasOmUz0Xw9IP7KjfzqTJE8iMC6MmxhNBeP4Me1YkeLE6xZdVyT4oZRF2FEU6kR7qhPsk
+        BT97hTtvni1tuL1jJCxdSViotHBYza1fcLThr5L06hvnU1SawVdffyL30OL5v4OwkLBhoAu4wH1b78HNzYXUSDXLZqovqbQge9NMFevSA1FKomwojnEhQWUj
+        1Vntdj13b6ih8egHdHT+XYalaxEWUm5p/1JCSPqtd17k1s2rCQnz4rEnHuTUmW7pqWW+/L8oYeGle0x64Dybb99EZNQM8pIiWZGlYUW8K+vSfNmcF8o9JZFs
+        KQpHKdBaUhLtSLy/BS4TFGZ4TuKem2s49uX7dOo+/6eEhVoL2xaExfzx3dvw9XfCwmoct2+5URYK/hlhna4RveHnqbTIk3v6hYS/Z/3Na0mbmUxVYZp0Wouj
+        bKVar0vzRsTkjVkBKKKsKWrF5TOcKAp3JCnAku23LuTk0Y/RdXxOd3cjYyUsnJYgOeqpr0wV33xzPykpMxg/XmH27Hy69U0y8TcP9nJ6eMSGj584REfHlwjC
+        Im8emx5ebcNX7q3HXo/kz719OkScn7+4ltjkKKpLU2TFckOWJ+vSp7Nxpi935Adzd1Eoiqj5inrvbK2dLKMm+k7mgQ3zOPb5B7S3/f2ahMeSFsQvQ2cDBw++
+        TXl5Ntdfr5CSEkljw2eyInH2GxN6fQOCsFjI7u7jP5uweahfVkWGhg1UzC4gNTeJ4lnxrMpTcVuuF3cXB3FfWSgP1URSXxeDIqr3AvOi7KiNdiA1cDIPbK6T
+        TutaKi3IjmI0VF026hplGaep6TO2bFmHvf1E3Fxt+fD9P8jalKGngcZjf0TX9bV87+dKeOi0iYGhXkzmNmbmx5FRlk1udqws0t+X68cDJSoerFBTXzuDXfOj
+        UZbFu7A8wZXlCc4sSnInXT2Nh+5awMmmj2ntvNpLj5L9R6MINaJINzDQRm9vM+8feI2U5Ggm3DCOJx6vZ3i4g6+OHuRk82fy+c8lPPyNWRIWpaPYlDBsfZwp
+        KUplU6GGR8tC2Ls8kb2rknlhfSavbMpDWZfhw6oUj8sI19+3mBMnDtKuOyILAFfa8D8iK+4LkiNopbe3laGhbo41HmF2dRE21hNZvXIuhz89QHvr5/T0HJd7
+        7dG9tHmo5xp76bE2e+W8F5NpBIaediJjtSiTxzErP4Z758ewa0Eoe5ZG8eqmHF7ekMnrt+WjjOaJi2KdZMMqQz2Nh+9ZQtOxj2VYEhWPn0PYYDgpHVdbawNb
+        t95OuMabOdW5/OXP72IeaJXPjAO6SwnET3Fa5kEDZ4cHOGXqpb+vi+SUaCZMUsjN0FA705t1eR7sXBTBrnkaSXxnXSiKaE4JxyU6dkvS/MgKsWPXPavoOP4X
+        9LqvpJP5KYRFGVZgVNJ9fS309bXJUq0oyf72N0+TkqQmPTWcA++9KjXA0NMqM6WhYZEFXSnFq69HC32DgzrOmvWcNrby7Wkdc6rTCfAcT3a8L8tq8njx4U28
+        fFcZz6yM4fn1yby6OQtFNLVE506WapN8yAiyvUTYIAkf+0kSvpKwydROv7EdEZZ6e9ppOXmY9w+8RGlxGsHB02VpVYQloc7XTg8F4R/TQTEfLeEOmXQMdB/n
+        lPEE0MPN62sI8JzA9ns38Prr77B2yVL23jGfg7sW8VF9LQfra1DK1PaUhzgwO8yJ2hhP2aN5esdG2psOSQkLD9zVcxKdoWkE+hOIuvMourqbGAuhwj2iJt3b
+        KiXb39860pkY7GVoqEdWQZtOHuKro39k3bpFREeF8OmhP3Lm9IDUArEwV8OIedAoC/WiWH8JJj2nzCLfbuEcRrb/aguOTrYkpudTMPcWMvIWsLSikLfqb+Kt
+        B6p5+75ClIowd6rC3GQBYG68HykqW0YJd+q+lDFWEBolKEZ9148QG4uxuIqwsf0ywn3GEwjCovwrYvJbb73Ee797jfa2RoRNjuBapHsZNBlGMErapGdwSId5
+        uJ0z53t4+Y3nUJTrCI3IYEbWYuauvpcF5UXsv38ZL99VwvMbUlBKQt0o1bhSFe5OdZwfCQG27N6+gZamQ4iMRtfxJXqxBbwC3V3HEDDomy5hhHgzhu4Wqb6i
+        zSLaLaaBLik1IWGx4WhtO0yn7igGwwmGh/WIRRKLOHzKgNmsH0N8dAFGxkFB0KSXmiDaN9K7D3VgNLdy7lwvb7+xH6dpU1H7a8gqWcDje/bz7v563np0Fc/d
+        lsUzN8Wh5Ac6yqZ3SYgj5REexPlasevBDZw4foiW9s8l6a7Oo5K4JC9SujEYK10x7+pulu2Tnt52evs6Lm4buxkcNEo77elrkiUeQ+9x6RtGSjydMjyZBnUM
+        Dl2rzDPiuEadlWjLjKALo7mdbmMz3/0wwIfvvY7ThOsI93Rny6b17N5xJ9vWFrJtcSzbFoRw/xw/lDKVE9UaV2q0rrJPnOBrwe6Hb0Hf9QVGc7PsBYldjKhF
+        CYg+To8IJ8Zm9H1N0r71vc30DLTTZ+rAMNAp81NROhXzXnMX/WInNDzA4Jk++k61cbz9CPr+JtkiEe+Jd+R7pww/vn/ayOCZfvmt+H4UA8N99Jl7MfR3092v
+        k3+3u6+d7/iO37/3Dn42U+QJhFXZKlZkuHBHuYp7a4J5aJGGR5dHoFRcdFhzwhyoDBPdeAs2LZnFi3u38u5bT3Pg3X188Lvnef8/90t8dODXfPzBK/zp4Kv8
+        18evcfiT3/HZp7/nvw8f4PMj79Pw5Z85fvQTWk4cpqP5vzF0fk2vvhFjdxP9PU10dRyRxYX25r+ia/sMEQl69V/T03VUjkZDI6bek5j7WxgaaJXfiO9GIe4P
+        9rVi6m2RMBvbMPa0ynz4zVefw/16RRYl78z3ZmuJBzvnadm5OJonVsXz5I1JKOURdrKJNjvMmvKQafL4w8yAaST4TpVIDbh40CXQGjFP9bNEHHqZqbKRRw9E
+        A10cYxC9ZdFnLo3ypDzWm5rkQOamqVmQqWFRdjhLc2JYlhfN/MxA5mb4Mi8jgAVZKhZmB7EoRy2v56b7y+cLs9UsztWwNC+MeRmqy7AsX8vygghWzIpkRWE8
+        dbmJpIX7UVueSkKoPfHuCjdm+3N7vi935Lhze/Z0bs/14NZZ3txa5INSEW1HVZQdFdpplKmnUhRsSaHGnuIZrhSGOcl5aZgjJRpxZMlBdikKg2zID7Ak128K
+        ef5TKVBZUBRsLaufom1TpLL6EUEWlKqsKQ+2p1xtS0WoBVVh00YWV2NJXbSdhLgnGnpl6snyHXFESRxPKlRNvITiwInUzLCVx5zksaZ4L4q07mjsx6F1Uwix
+        U5iX6MrGAn825XpK0nfmeHN7jhcbcz1Zn+uFUhXlgJBySZgVhSFWFKht5bmsmWo7ZqptyAmyIS9YHFlyoEjjRL7KhrxAa7L9LMn0mUK2/zR52kcsiOhNiV6V
+        WBhxOkegLMweUfsWhf7iYEt5/EgcQRKo0ljLf74uwh6B2sgRiHS1OMRCal5FuK2ci+tKra1EVbgD5aE2I8ebYr3kaSCRz4vTQosSXViZ7MLadFfWz3RH5MQC
+        67M9uSnbm/8BW+VlE2vcc5gAAAAASUVORK5CYII=
+      </data>
+      <mime>image/png</mime>
+      <width>60</width>
+      <height>41</height>
+      <resource-attributes>
+        <file-name>photo.png</file-name>
+        <source-url>
+          en-cache://tokenKey%3D%22AuthToken%3AUser%3A0000000%22+00000000-0000-0000-0000-0000000000000+64c11ef139c91b3826da3b5a4989a9ca+https://www.evernote.com/shard/s30/res/00000000-0000-0000-0000-000000000000
+        </source-url>
+      </resource-attributes>
+    </resource>
+  </note>
+</en-export>

--- a/test/data/test-image-dataUrl.md
+++ b/test/data/test-image-dataUrl.md
@@ -1,0 +1,15 @@
+# test - image - dataUrl
+
+![embedded.png](./_resources/test_-_image_-_dataUrl.resources/embedded.png)
+![embedded.1.svg](./_resources/test_-_image_-_dataUrl.resources/embedded.1.svg) Photo by [Mike Tinnion](https://unsplash.com/@m15ky)
+![embedded.2.svg](./_resources/test_-_image_-_dataUrl.resources/embedded.2.svg)
+[Free to use under the Unsplash License](https://unsplash.com/license)
+
+![photo.png](./_resources/test_-_image_-_dataUrl.resources/photo.png)
+
+![embedded.3.svg](./_resources/test_-_image_-_dataUrl.resources/embedded.3.svg)
+
+    Created at: 2021-07-17T18:35:45+01:00
+    Updated at: 2021-07-17T23:33:56+01:00
+    Source URL: https://unsplash.com/photos/3ym6i13Y9LU
+

--- a/test/yarle-special-cases.spec.ts
+++ b/test/yarle-special-cases.spec.ts
@@ -276,6 +276,38 @@ describe('Yarle special cases', async () => {
     );
   });
 
+  it('Enex file with images using data urls', async () => {
+    const options: YarleOptions = {
+      enexSource: `${testDataFolder}test-image-dataUrl.enex`,
+      outputDir: 'out',
+      isMetadataNeeded: true,
+    };
+    await yarle.dropTheRope(options);
+    assert.equal(
+      fs.existsSync(
+        `${__dirname}/../out/notes/test-image-dataUrl/test - image - dataUrl.md`,
+      ),
+      true,
+    );
+    assert.equal(
+      eol.auto(fs.readFileSync(
+        `${__dirname}/../out/notes/test-image-dataUrl/test - image - dataUrl.md`,
+        'utf8',
+      )),
+      fs.readFileSync(`${__dirname}/data/test-image-dataUrl.md`, 'utf8'),
+    );
+
+    // Make sure data-url and en-media resources all exist.
+    // (Really, we ought to be checking specific resource contents --
+    // e.g., with chai-fs `assert.directoryEqual(outResourcesDir, expectedResourcesDir)`.)
+    ['embedded.png', 'embedded.1.svg', 'embedded.2.svg', 'embedded.3.svg', 'photo.png'].forEach(
+      resource => assert(
+        fs.existsSync(
+          `${__dirname}/../out/notes/test-image-dataUrl/_resources/test_-_image_-_dataUrl.resources/${resource}`,
+        ),
+        `Resource file ${resource} not created`,
+      ));
+  });
 
   it('Enex file with two notes with same names', async () => {
     const options: YarleOptions = {


### PR DESCRIPTION
Extract the data url from `<img src="data:...">` into resources,
and patch up the src.

(EN 10's web clipper uses data urls for SVG images.
This change should handle any `src="data:..."` for any
media types.)