### PR TITLE
Clarification of binary package type

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Yarle is the ultimate converter of Evernote notes to Markdown.
 
 [Windows](https://github.com/akosbalasko/yarle/releases/download/v4.1.0/yarle-evernote-to-md-4.1.0.Setup.exe)
 
-[Linux](https://github.com/akosbalasko/yarle/releases/download/v4.1.0/yarle-evernote-to-md-4.1.0-1.x86_64.rpm)
+[Linux (.rpm)](https://github.com/akosbalasko/yarle/releases/download/v4.1.0/yarle-evernote-to-md-4.1.0-1.x86_64.rpm)
 
-[Debian](https://github.com/akosbalasko/yarle/releases/download/v4.1.0/yarle-evernote-to-md_4.1.0_amd64.deb)
+[Debian (.deb)](https://github.com/akosbalasko/yarle/releases/download/v4.1.0/yarle-evernote-to-md_4.1.0_amd64.deb)
 
 [Mac](https://github.com/akosbalasko/yarle/releases/download/v4.1.0/yarle-evernote-to-md-darwin-x64-4.1.0.zip)
 


### PR DESCRIPTION
If folks are less familiar with Linux or not paying close attention (like I was today :sweat_smile:), these download options will be confusing to them. The link under Debian is for Debian and derivatives, which includes Ubuntu and thus most desktop Linux distros. Linux links to an `.rpm`, which works for Fedora, CentOS, and RHEL. 

I'm offering a minor annotation to acknowledge that without too much explanation.