### PR TITLE
Use 'env' to find 'node' interpreter path

### DIFF
--- a/src/dropTheRope.ts
+++ b/src/dropTheRope.ts
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node --max-old-space-size=1024
+#!/usr/bin/env node --max-old-space-size=1024
 /* istanbul ignore file */
 // tslint:disable:no-console
 


### PR DESCRIPTION
Not every system have `node` installed in `/usr/local/bin`. It can be in `/usr/bin`, or for people using `n` or `nvm`, it will be in their home directory.

Using `env` to find an interpreter is a common thing in scripts, and will resolve this issue.