### PR TITLE
feat: Sanitize spaces from resources names

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,12 @@ The following configurational properties are available:
 |```keepMDCharactersOfENNotes```| true or false | set it true, if you used Markdown format in your EN notes|
 | ```nestedTags``` | it's a complex property contains the following subitems: "separatorInEN", "replaceSeparatorWith" and  "replaceSpaceWith" | separatorInEN stores the tag separator used in Evernote, replaceSeparatorWith is the string to what separatorInEN should be replaced to, and replaceSpaceWith is the string to what the space character should be replaced to in the tags. For example using the default settings a tag ```tag1_sub tag of tag1``` is going to be converted to ```tag1/sub-tag-of-tag1```
 | ```keepImageSize``` | `ObsidianMD` or `StandardMD` | preserve an image's width and height in the chosen format when specified
-| ```urlEncodeFileNamesAndLinks``` | true or false | URL-encodes linked file names and internal EN links . e.g "linked file.jpg" will be converted to "linked%20file.jpg" 
-| ```keepOriginalAmountOfNewlines``` | true or false | keep the original amount of newlines, default is false, when the multiple newlines are collapsed to one. 
-| ```generateNakedUrls``` | true or false | if it's true, Yarle generates 'naked' external Urls without any extra characters. If its false, external Urls are wrapped by  '<' and '>' characters  
-| ```addExtensionToInternalLinks``` | true or false | adds '.md' extensions at the end of internal file links, to make them recognizable by DevonThink and other tools 
+| ```urlEncodeFileNamesAndLinks``` | true or false | URL-encodes linked file names and internal EN links . e.g "linked file.jpg" will be converted to "linked%20file.jpg"
+| ```sanitizeResourceNameSpaces``` | true or false | Replace spaces in resource names with the `replacementChar`. e.g "linked file.jpg" will be converted to "linked_file.jpg"
+| ```replacementChar``` | string | the replacement character. e.g "linked*file.jpg" will be converted to "linked_file.jpg". It defaults to "_"
+| ```keepOriginalAmountOfNewlines``` | true or false | keep the original amount of newlines, default is false, when the multiple newlines are collapsed to one.
+| ```generateNakedUrls``` | true or false | if it's true, Yarle generates 'naked' external Urls without any extra characters. If its false, external Urls are wrapped by  '<' and '>' characters
+| ```addExtensionToInternalLinks``` | true or false | adds '.md' extensions at the end of internal file links, to make them recognizable by DevonThink and other tools
 | ```turndownOptions``` | `{...}` | additional configuration options for [turndown](https://github.com/mixmark-io/turndown#options), e.g., `{ "bulletListMarker": "-" }` (only in Yarle config file, not desktop app)
 | ```logseqSettings``` | `{...}` | settings for Logseq output, currently ```journalNotes``` property is supported, if it is set to `true`, then the notes will be converted to be recognizable by Logseq as Journal notes, the notes will be named by their creation date and they will be collected under `journal` folder. If it is `false`, then they will be converted to be `Pages` (e.g. simple notes, collected in `pages` folder).
 

--- a/src/YarleOptions.ts
+++ b/src/YarleOptions.ts
@@ -28,6 +28,7 @@ export interface YarleOptions {
     haveEnexLevelResources?: boolean;
     keepMDCharactersOfENNotes?: boolean;
     urlEncodeFileNamesAndLinks?: boolean;
+    sanitizeResourceNameSpaces?: boolean;
     monospaceIsCodeBlock?: boolean;
     dateFormat?: string;
     nestedTags?: TagSeparatorReplaceOptions;

--- a/src/YarleOptions.ts
+++ b/src/YarleOptions.ts
@@ -29,6 +29,7 @@ export interface YarleOptions {
     keepMDCharactersOfENNotes?: boolean;
     urlEncodeFileNamesAndLinks?: boolean;
     sanitizeResourceNameSpaces?: boolean;
+    replacementChar?: string;
     monospaceIsCodeBlock?: boolean;
     dateFormat?: string;
     nestedTags?: TagSeparatorReplaceOptions;

--- a/src/utils/filename-utils.ts
+++ b/src/utils/filename-utils.ts
@@ -34,11 +34,14 @@ export const getResourceFileProperties = (workDir: string, resource: any): Resou
 
   if (resource['resource-attributes'] && resource['resource-attributes']['file-name']) {
     const fileNamePrefix = resource['resource-attributes']['file-name'].substr(0, 50);
-
     fileName = fileNamePrefix.split('.')[0];
-
   }
   fileName = fileName.replace(/[/\\?%*:|"<>]/g, '-');
+
+  if (yarleOptions.sanitizeResourceNameSpaces) {
+    fileName = fileName.replace(/ /g, '-');
+  }
+
   const index = getFileIndex(workDir, fileName);
   const fileNameWithIndex = index > 0 ? `${fileName}.${index}` : fileName;
 

--- a/src/utils/filename-utils.ts
+++ b/src/utils/filename-utils.ts
@@ -10,10 +10,10 @@ import { ResourceFileProperties } from './../models/ResourceFileProperties';
 import { OutputFormat } from './../output-format';
 import { getCreationTime } from './content-utils';
 
-const FILENAME_DELIMITER = '_';
-
 export const normalizeTitle = (title: string) => {
-  return sanitize(title, {replacement: FILENAME_DELIMITER});
+  // Allow setting a specific replacement character for file and resource names
+  // Default to a retrocompatible value
+  return sanitize(title, {replacement: yarleOptions.replacementChar || '_'});
 };
 
 export const getFileIndex = (dstPath: string, fileNamePrefix: string): number | string => {
@@ -39,7 +39,7 @@ export const getResourceFileProperties = (workDir: string, resource: any): Resou
   fileName = fileName.replace(/[/\\?%*:|"<>]/g, '-');
 
   if (yarleOptions.sanitizeResourceNameSpaces) {
-    fileName = fileName.replace(/ /g, '-');
+    fileName = fileName.replace(/ /g, yarleOptions.replacementChar);
   }
 
   const index = getFileIndex(workDir, fileName);

--- a/src/utils/turndown-rules/images-rule.ts
+++ b/src/utils/turndown-rules/images-rule.ts
@@ -15,9 +15,9 @@ export const imagesRule = {
     const value = nodeProxy.src.value;
     let realValue = value;
     if (yarleOptions.sanitizeResourceNameSpaces) {
-      realValue = realValue.replaceAll(' ', '-');
+      realValue = realValue.replaceAll(' ', yarleOptions.replacementChar);
     } else if (yarleOptions.urlEncodeFileNamesAndLinks) {
-      realValue = encodeURI(value);
+      realValue = encodeURI(realValue);
     }
 
     // while this isn't really a standard, it is common enough

--- a/src/utils/turndown-rules/images-rule.ts
+++ b/src/utils/turndown-rules/images-rule.ts
@@ -13,7 +13,12 @@ export const imagesRule = {
       return '';
     }
     const value = nodeProxy.src.value;
-    const realValue = yarleOptions.urlEncodeFileNamesAndLinks ? encodeURI(value) : value;
+    let realValue = value;
+    if (yarleOptions.sanitizeResourceNameSpaces) {
+      realValue = realValue.replaceAll(' ', '-');
+    } else if (yarleOptions.urlEncodeFileNamesAndLinks) {
+      realValue = encodeURI(value);
+    }
 
     // while this isn't really a standard, it is common enough
     if (yarleOptions.keepImageSize === OutputFormat.StandardMD || yarleOptions.keepImageSize === OutputFormat.LogSeqMD) {


### PR DESCRIPTION
Recently, I faced the issue of finding broken image links on my Obsidian test export. These were broken because they had spaces in them.
After looking a bit around, I found that I could use `urlEncodeFileNamesAndLinks` and that that was in fact the [standard markdown approach](https://forum.obsidian.md/t/markdown-image-links-failing-for-filenames-with-whitespace/943).

However, enabling `urlEncodeFileNamesAndLinks` renames all my note in a way that makes them harder to find and reason about. Consequently, I thought the best approach would be to simply remove spaces from resource names, as regular links work fine with spaces.

In my approach, I added a `sanitizeResourceNameSpaces` flag and applied this transform both on the filename-utils side and on the image-rules, so the links would match.
In order to make this possible, I extracted `replacementChar` as a config. This is also useful in my usecase, as I prefer '-' rather than the default '_' used in sanitization.

Hope this is useful to everyone :)