### PR TITLE
Fix: en-todo wrapping and content lost on nested lists

### DIFF
--- a/src/convert-html-to-md.ts
+++ b/src/convert-html-to-md.ts
@@ -10,10 +10,10 @@ const unwrapElement = (node: Element) => {
 };
 
 const swapParent = (wrapper: Element) => {
-    const span = wrapper.parentElement;
-    span.replaceWith(...Array.from(span.childNodes));
-    span.append(...Array.from(wrapper.childNodes));
-    wrapper.appendChild(span);
+    const inner = wrapper.parentElement;
+    inner.replaceWith(...Array.from(inner.childNodes));
+    inner.append(...Array.from(wrapper.childNodes));
+    wrapper.appendChild(inner);
 };
 
 const fixTasks = (node: HTMLElement) => {
@@ -33,28 +33,42 @@ const fixSublists = (node: HTMLElement) => {
     const ulElements: Array<HTMLElement> = Array.from(node.getElementsByTagName('ul'));
     const olElements: Array<HTMLElement> = Array.from(node.getElementsByTagName('ol'));
     const listElements = ulElements.concat(olElements);
+
     listElements.forEach(listNode => {
-      if (listNode.parentElement.tagName === 'LI') {
-        listNode.parentElement.replaceWith(listNode);
-      }
-      if (
-        listNode.previousElementSibling &&
-        listNode.previousElementSibling.tagName === 'LI'
-      ) {
-        // The below moves, not copies. https://stackoverflow.com/questions/7555442/move-an-element-to-another-parent-after-changing-its-id
-        listNode.previousElementSibling.appendChild(listNode);
-      }
+        if (listNode.parentElement.tagName === 'LI') {
+            listNode.parentElement.replaceWith(listNode);
+        }
+        if (
+            listNode.previousElementSibling &&
+            listNode.previousElementSibling.tagName === 'LI'
+        ) {
+            // The below moves, not copies. https://stackoverflow.com/questions/7555442/move-an-element-to-another-parent-after-changing-its-id
+            listNode.previousElementSibling.appendChild(listNode);
+        }
     });
+
+    for (const n of listElements) {
+        const parentElement = n.parentElement;
+        if (parentElement?.tagName === 'DIV' &&
+            parentElement?.parentElement?.tagName === 'UL') {
+            unwrapElement(parentElement);
+        }
+        // remove nested lists whose only child is another list, i.e. <ul><ul>...</ul></ul>
+        if ((parentElement?.tagName === 'UL' || parentElement?.tagName === 'OL')
+            && parentElement?.childNodes.length === 1) {
+            unwrapElement(parentElement);
+        }
+    }
 
     // The contents of every EN list item are wrapped by a div element. `<li><div>foo</div></li>`
     // We need to remove this `<div>`, since it's a block element and will lead to unwanted whitespace otherwise
     const liElements: Array<HTMLElement> = Array.from(node.getElementsByTagName('li'));
     for (const liNode of liElements) {
-      const listNodeDiv = liNode.firstElementChild;
-      if (listNodeDiv && listNodeDiv.tagName === 'DIV') {
-        const childElementsArr = Array.from(listNodeDiv.childNodes);
-        listNodeDiv.replaceWith(...childElementsArr);
-      }
+        const listNodeDiv = liNode.firstElementChild;
+        if (listNodeDiv && listNodeDiv.tagName === 'DIV') {
+            const childElementsArr = Array.from(listNodeDiv.childNodes);
+            listNodeDiv.replaceWith(...childElementsArr);
+        }
     }
 
     return node;


### PR DESCRIPTION
This PR is two-fold and it covers two different aspects in pre-parsing
an en-note before converting it

* It fixes `en-todo` wrapping:
  * `[[] foo](bar)` -> `[] [foo](bar)`
  * `*[] foo*` -> `[] *foo*`
* It fixes losing content on nested lists (for older Evernote versions) following the approach
  described in https://github.com/akosbalasko/yarle/issues/324#issuecomment-986269013. I further narrowed the check, so as not to break the tests