### PR TITLE
fix: Replace brackets and plus sign on filenames

### DIFF
--- a/src/utils/filename-utils.ts
+++ b/src/utils/filename-utils.ts
@@ -41,7 +41,7 @@ export const getResourceFileProperties = (workDir: string, resource: any): Resou
     const fileNamePrefix = resource['resource-attributes']['file-name'].substr(0, 50);
     fileName = fileNamePrefix.split('.')[0];
   }
-  fileName = fileName.replace(/[/\\?%*:|"<>\[\]]/g, '-');
+  fileName = fileName.replace(/[/\\?%*:|"<>\[\]\+]/g, '-');
 
   if (yarleOptions.sanitizeResourceNameSpaces) {
     fileName = fileName.replace(/ /g, yarleOptions.replacementChar);

--- a/src/utils/filename-utils.ts
+++ b/src/utils/filename-utils.ts
@@ -41,7 +41,7 @@ export const getResourceFileProperties = (workDir: string, resource: any): Resou
     const fileNamePrefix = resource['resource-attributes']['file-name'].substr(0, 50);
     fileName = fileNamePrefix.split('.')[0];
   }
-  fileName = fileName.replace(/[/\\?%*:|"<>]/g, '-');
+  fileName = fileName.replace(/[/\\?%*:|"<>\[\]]/g, '-');
 
   if (yarleOptions.sanitizeResourceNameSpaces) {
     fileName = fileName.replace(/ /g, yarleOptions.replacementChar);


### PR DESCRIPTION
I noticed some of my note attachments weren't getting converted due to either having `[]` or `+` in their filename.

I replaced those chars to tackle this :)