### PR TITLE
Fix: Obsidian image sizes

### DIFF
--- a/src/utils/turndown-rules/images-rule.ts
+++ b/src/utils/turndown-rules/images-rule.ts
@@ -28,9 +28,8 @@ export const imagesRule = {
 
       return `![](${realValue}${sizeString})`;
     } else if (yarleOptions.keepImageSize === OutputFormat.ObsidianMD) {
+      sizeString = (widthParam || heightParam) ? `|${widthParam || 0}x${heightParam || 0}` : '';
       if (realValue.startsWith('./')) {
-        sizeString = (widthParam || heightParam) ? `|${widthParam}x${heightParam}` : '';
-
         return `![[${realValue}${sizeString}]]`;
       } else {
         return `![${sizeString}](${realValue})`;


### PR DESCRIPTION
I noticed Obsidian images got broken due to https://github.com/akosbalasko/yarle/pull/326. This should now be fixed
👍 