### PR TITLE
fix:Reference Error in UI Log

### DIFF
--- a/src/ui/main.js
+++ b/src/ui/main.js
@@ -6,6 +6,7 @@ const { initialize, enable } = require("@electron/remote/main")
 const { mapSettingsToYarleOptions } = require('./settingsMapper')
 const yarle = require('../yarle')
 const {OutputFormat} = require('./../output-format')
+const { applyLinks } = require('./../utils/apply-links');
 
 initialize();
 // tslint:disable-next-line:no-require-imports variable-name


### PR DESCRIPTION
I was getting an error like this on the commmandline:

~~~
(node:911326) UnhandledPromiseRejectionWarning: ReferenceError: applyLinks is not defined                                                                                            
    at IpcMainImpl.<anonymous> (/home/~/Source/Clones/yarle/dist/ui/main.js:71:7)                                                                                                
    at process.processTicksAndRejections (node:internal/process/task_queues:96:5)                                                                                                    
(Use `electron --trace-warnings ...` to show where the warning was created)                                                                                                          
(node:911326) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by reject
ing a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs
.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)                                                                                                                  
clearing log: /home/~/.yarle-evernote-to-md/conversion.log                                                                                                                       
(node:911326) UnhandledPromiseRejectionWarning: ReferenceError: applyLinks is not defined                                                                                            
    at IpcMainImpl.<anonymous> (/home/~/Source/Clones/yarle/dist/ui/main.js:71:7)                                                                                                
    at process.processTicksAndRejections (node:internal/process/task_queues:96:5)                                                                                                    
(node:911326) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by reject
ing a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs
.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)  
~~~

It seemed to be missing a reference and adding this line cleaned up the error.