### PR TITLE
configs saved with timestamps

### DIFF
--- a/src/ui/main.js
+++ b/src/ui/main.js
@@ -182,10 +182,8 @@ app.whenReady().then(() => {
         return
       } else if (filePaths) {
         const configFilePath = filePaths[0];
-        const fileContent = fs.readFileSync(configFilePath, {encoding: 'base64'});
-        let plainConfig = Buffer.from(fileContent, 'base64').toString('utf8')
-        plainConfig = Buffer.from(plainConfig, 'base64').toString('utf8')
-        mainWindow.webContents.send('configLoaded', configFilePath, JSON.parse(plainConfig));
+        const fileContent = fs.readFileSync(configFilePath);
+        mainWindow.webContents.send('configLoaded', configFilePath, JSON.parse(fileContent));
       }
 
   });

--- a/src/yarle.ts
+++ b/src/yarle.ts
@@ -203,8 +203,11 @@ export const parseStream = async (options: YarleOptions, enexSource: string): Pr
 };
 
 const saveOptionsAsConfig = (options: YarleOptions): void => {
-  const yarleConfigName = 'yarle.config'
-  const encoded = Buffer.from(JSON.stringify(options), 'utf8').toString('base64')
+  const now = new Date();
+  const formattedDateString = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}_${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(now.getSeconds()).padStart(2, '0')}`;
+
+  const yarleConfigName = `yarle_${formattedDateString}.config`;
+  const encoded = Buffer.from(JSON.stringify(options))
   fs.writeFileSync(path.join(options.outputDir, yarleConfigName), encoded);
 }
 export const dropTheRope = async (options: YarleOptions): Promise<Array<string>> => {


### PR DESCRIPTION
BREAKING CHANGE: configs are saved as plain text, no base64 encoding
