### PR TITLE
fix: note links note being replaced correctly when  keepEvernoteLinkIfNoNoteFound = true (#653)

### DIFF
--- a/src/utils/apply-links.ts
+++ b/src/utils/apply-links.ts
@@ -71,18 +71,17 @@ export const applyLinks = (options: YarleOptions, outputNotebookFolders: Array<s
                     }
 
                 }
-                if (options.keepEvernoteLinkIfNoNoteFound){
-                    if (linkDoesntExist){
-                        const regexp = new RegExp(`<YARLE_EVERNOTE_LINK>(.)*<-->`)// replace
-                        updatedContent = updatedContent.replace(regexp, '');
-                        updatedContent = updatedContent.replace('</YARLE_EVERNOTE_LINK>', '');
+                if (options.keepEvernoteLinkIfNoNoteFound) {
+                    const id = escapeStringRegexp(linkName);
+                    const regexp = new RegExp(`<YARLE_EVERNOTE_LINK>${id}<-->(.*?)<-->(.*?)<\/YARLE_EVERNOTE_LINK>`, 'g');
 
-                    }else {
-                        const regexp = new RegExp(`<-->(.)*<\/YARLE_EVERNOTE_LINK>`)// replace
-                        updatedContent = updatedContent.replace(regexp, '');
-                        updatedContent = updatedContent.replace('<YARLE_EVERNOTE_LINK>', '');
-                    }
-
+                    updatedContent = updatedContent.replace(regexp, (match, firstGroup, secondGroup) => {
+                        if (linkDoesntExist) {
+                            return secondGroup;
+                        } else {
+                            return firstGroup.replace(new RegExp(id, 'g'), realFileNameInContent);
+                        }
+                    });
                 }
                 else {
                     const regexp = new RegExp(escapeStringRegexp(linkName), 'g');

--- a/src/utils/turndown-rules/internal-links-rule.ts
+++ b/src/utils/turndown-rules/internal-links-rule.ts
@@ -113,7 +113,7 @@ export const wikiStyleLinksRule = {
                 return `${mdKeyword}[[${linkedNoteId}${extension}${renderedObsidianDisplayName}]]`;
             }
             if (yarleOptions.keepEvernoteLinkIfNoNoteFound){
-                return `<YARLE_EVERNOTE_LINK>${mdKeyword}[[${linkedNoteId}${extension}${renderedObsidianDisplayName}]]<-->[${displayName}](${linkedNoteId}${extension})</YARLE_EVERNOTE_LINK>`
+                return `<YARLE_EVERNOTE_LINK>${linkedNoteId}<-->${mdKeyword}[[${linkedNoteId}${extension}${renderedObsidianDisplayName}]]<-->[${displayName}](${linkedNoteId}${extension})</YARLE_EVERNOTE_LINK>`
             }
 
             return `${mdKeyword}[${displayName}](${linkedNoteId}${extension})`;


### PR DESCRIPTION
Addresses #653

The original regexes were greedy, which would wipe out many links on the same line, but also the resulting link still contains the original Evernote link, it wasn't getting replaced at all. I updated the intermediate <YARLE_EVERNOTE_LINK> format to contain the original note id to guarantee a correct match, then replace the link format appropriately.