### PR TITLE
feat: recursive .enex discovery with stack folder/naming structure support

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,24 @@ The following configurational properties are available:
 |```keepEvernoteLinkIfNoNoteFound```| boolean | it keeps the link to the evernote note if no such note found among the converted files
 |```convertColorsToMDHighlight```| boolean | it converts colored highlights and custom font spans to standard markdown highlights
 |```removeUnicodeCharsFromTags```| boolean | it removes the unicode characters (like éáűőú) from tags 
+| `preserveStackFolderStructure` | false | When converting a directory, recreate subdirectory (stack) hierarchy in the output folder structure. E.g., `Stack/Notebook.enex` outputs to `notes/Stack/Notebook/` |
+| `preserveStackNamingStructure` | false | When converting a directory, prefix output folder names with the stack name. E.g., `Stack/Notebook.enex` outputs to `notes/Stack - Notebook/`. Ignored when `preserveStackFolderStructure` is `true` |
  
 Metadata settings can be set via the template.
+
+### Evernote Stacks (Nested Directories)
+
+When `enexSources` points to a directory, yarle recursively scans all subdirectories for `.enex` files. This supports Evernote's "stack" export format where stacks become subdirectories.
+
+By default, all discovered `.enex` files are output to flat folders. Use the options below to control how stack hierarchy appears in output:
+
+| `preserveStackFolderStructure` | `preserveStackNamingStructure` | Output for `Stack/Notebook.enex` |
+|---|---|---|
+| `false` (default) | `false` (default) | `notes/Notebook/` |
+| `true` | n/a | `notes/Stack/Notebook/` |
+| `false` | `true` | `notes/Stack - Notebook/` |
+
+If a name collision is detected (e.g., `Notebook.enex` exists at both the top level and inside a stack), `preserveStackNamingStructure` is automatically enabled to prevent data loss.
 
 
 ## Note links over notebooks? No problem, here is what to do: 

--- a/src/YarleOptions.ts
+++ b/src/YarleOptions.ts
@@ -73,4 +73,10 @@ export interface YarleOptions {
     keepEvernoteLinkIfNoNoteFound?: boolean;
     convertColorsToMDHighlight?: boolean;
     globalReplacementSettings?: Array<SearchAndReplace>;
+    preserveStackFolderStructure?: boolean;
+    preserveStackNamingStructure?: boolean;
+    // Internal: maps enex full paths to their relative stack directory (set by expandEnexSourceDirs)
+    _enexRelativeDirs?: Record<string, string>;
+    // Internal: the relative stack dir for the enex file currently being processed
+    _currentEnexRelativeDir?: string;
 }

--- a/src/dropTheRopeRunner.ts
+++ b/src/dropTheRopeRunner.ts
@@ -1,7 +1,6 @@
 /* istanbul ignore file */
 // tslint:disable:no-console
 
-import * as fs from 'fs';
 import * as path from 'path';
 
 import * as yarle from './yarle';
@@ -10,6 +9,7 @@ import { loggerInfo } from './utils/loggerInfo';
 import { clearLogFile } from './utils/clearLogFile';
 import { applyLinks } from './utils/apply-links';
 import { LanguageFactory } from './outputLanguages/LanguageFactory';
+import { expandEnexSourceDirs } from './utils/discover-enex-files';
 
 export const run = async (opts?: YarleOptions) => {
     clearLogFile();
@@ -25,13 +25,7 @@ export const run = async (opts?: YarleOptions) => {
     if (options.enexSources.length === 1 && options.enexSources[0].endsWith('.enex')) {
         loggerInfo(`Converting notes in file: ${options.enexSources}`);
     } else {
-        const enexFiles = fs
-            .readdirSync(options.enexSources[0])
-            .filter((file: any) => {
-                return file.match(/.*\.enex/ig);
-            });
-
-        options.enexSources = enexFiles.map(enexFile => `${options.enexSources[0]}${path.sep}${enexFile}`);
+        expandEnexSourceDirs(options);
     }
     const outputNotebookFolders = await yarle.dropTheRope(options);
 

--- a/src/dropTheRopeRunner.ts
+++ b/src/dropTheRopeRunner.ts
@@ -9,9 +9,8 @@ import { loggerInfo } from './utils/loggerInfo';
 import { clearLogFile } from './utils/clearLogFile';
 import { applyLinks } from './utils/apply-links';
 import { LanguageFactory } from './outputLanguages/LanguageFactory';
-import { expandEnexSourceDirs } from './utils/discover-enex-files';
 
-export const run = async (opts?: YarleOptions) => {
+export const run = async (opts?: YarleOptions) => {
     clearLogFile();
     // tslint:disable-next-line:no-require-imports
     const argv = require('minimist')(process.argv.slice(2));
@@ -22,14 +21,9 @@ export const run = async (opts?: YarleOptions) => {
         : `${__dirname}/../config.json`;
     console.log(`Loading config from ${configFile}`);
     const options: YarleOptions = {...require(configFile), ...opts};
-    if (options.enexSources.length === 1 && options.enexSources[0].endsWith('.enex')) {
-        loggerInfo(`Converting notes in file: ${options.enexSources}`);
-    } else {
-        expandEnexSourceDirs(options);
-    }
     const outputNotebookFolders = await yarle.dropTheRope(options);
 
-    // POSTPROCESSES 
+    // POSTPROCESSES
     // apply internal links
     applyLinks(options, outputNotebookFolders);
 

--- a/src/utils/discover-enex-files.ts
+++ b/src/utils/discover-enex-files.ts
@@ -27,10 +27,12 @@ const findEnexFilesRecursively = (sourceDir: string, relativeDir: string = ''): 
 };
 
 export const expandEnexSourceDirs = (options: YarleOptions): void => {
-    if (options.enexSources.length === 1 && options.enexSources[0].endsWith('.enex')) {
+    // If all entries are already .enex file paths, nothing to expand
+    if (options.enexSources.every(s => s.endsWith('.enex'))) {
         return;
     }
 
+    // Expand the first directory source (matches original CLI behavior)
     const sourceDir = options.enexSources[0];
 
     if (!fs.statSync(sourceDir).isDirectory()) {

--- a/src/utils/discover-enex-files.ts
+++ b/src/utils/discover-enex-files.ts
@@ -1,0 +1,67 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { YarleOptions } from '../YarleOptions';
+import { loggerInfo } from './loggerInfo';
+
+interface EnexFileEntry {
+    fullPath: string;
+    relativeDir: string;
+}
+
+const findEnexFilesRecursively = (sourceDir: string, relativeDir: string = ''): EnexFileEntry[] => {
+    const results: EnexFileEntry[] = [];
+    const currentDir = relativeDir ? `${sourceDir}${path.sep}${relativeDir}` : sourceDir;
+    const entries = fs.readdirSync(currentDir);
+
+    for (const entry of entries) {
+        const fullEntryPath = `${currentDir}${path.sep}${entry}`;
+        if (fs.statSync(fullEntryPath).isDirectory()) {
+            const subRelativeDir = relativeDir ? `${relativeDir}${path.sep}${entry}` : entry;
+            results.push(...findEnexFilesRecursively(sourceDir, subRelativeDir));
+        } else if (entry.match(/.*\.enex$/i)) {
+            results.push({ fullPath: fullEntryPath, relativeDir });
+        }
+    }
+
+    return results;
+};
+
+export const expandEnexSourceDirs = (options: YarleOptions): void => {
+    if (options.enexSources.length === 1 && options.enexSources[0].endsWith('.enex')) {
+        return;
+    }
+
+    const sourceDir = options.enexSources[0];
+
+    if (!fs.statSync(sourceDir).isDirectory()) {
+        return;
+    }
+
+    const enexEntries = findEnexFilesRecursively(sourceDir);
+
+    const relativeDirs: Record<string, string> = {};
+    for (const entry of enexEntries) {
+        relativeDirs[entry.fullPath] = entry.relativeDir;
+    }
+
+    // Detect name collisions in flat mode and auto-promote to naming structure
+    if (!options.preserveStackFolderStructure && !options.preserveStackNamingStructure) {
+        const nameCount = new Map<string, number>();
+        for (const entry of enexEntries) {
+            const baseName = path.basename(entry.fullPath, '.enex').toLowerCase();
+            nameCount.set(baseName, (nameCount.get(baseName) || 0) + 1);
+        }
+
+        for (const [baseName, count] of nameCount) {
+            if (count > 1) {
+                loggerInfo(`WARNING: Name collision detected for "${baseName}.enex" (${count} files). ` +
+                    `Auto-enabling preserveStackNamingStructure to avoid data loss.`);
+                options.preserveStackNamingStructure = true;
+                break;
+            }
+        }
+    }
+
+    options._enexRelativeDirs = relativeDirs;
+    options.enexSources = enexEntries.map(entry => entry.fullPath);
+};

--- a/src/utils/folder-utils.ts
+++ b/src/utils/folder-utils.ts
@@ -129,25 +129,32 @@ export const clearMdNotesDistDir = (): void => {
 };
 
 export const setPaths = (enexSource: string): void => {
-  // loggerInfo('setting paths');
   const enexFolder = enexSource.split(path.sep);
-  // loggerInfo(`enex folder split: ${JSON.stringify(enexFolder)}`);
   let enexFile = (enexFolder.length >= 1 ?  enexFolder[enexFolder.length - 1] : enexFolder[0]).split(/.enex$/)[0];
   enexFile = normalizeFilenameString(enexFile);
-  // loggerInfo(`enex file: ${enexFile}`);
 
   const outputDir = path.isAbsolute(yarleOptions.outputDir)
     ? yarleOptions.outputDir
     : `${process.cwd()}${path.sep}${yarleOptions.outputDir}`;
 
+  const relativeDir = yarleOptions._currentEnexRelativeDir || '';
+
+  let notebookFolder = enexFile;
+
+  if (relativeDir) {
+    if (yarleOptions.preserveStackFolderStructure) {
+      notebookFolder = `${relativeDir}${path.sep}${enexFile}`;
+    } else if (yarleOptions.preserveStackNamingStructure) {
+      notebookFolder = `${relativeDir} - ${enexFile}`;
+    }
+  }
+
   paths.mdPath = `${outputDir}${path.sep}notes${path.sep}`;
   paths.resourcePath = `${outputDir}${path.sep}notes${path.sep}${yarleOptions.resourcesDir}`;
 
-  // loggerInfo(`Skip enex filename from output? ${yarleOptions.skipEnexFileNameFromOutputPath}`);
   if (!yarleOptions.skipEnexFileNameFromOutputPath) {
-    paths.mdPath = `${paths.mdPath}${enexFile}`;
-    // loggerInfo(`mdPath: ${paths.mdPath}`);
-    paths.resourcePath = `${outputDir}${path.sep}notes${path.sep}${enexFile}${path.sep}${yarleOptions.resourcesDir}`;
+    paths.mdPath = `${paths.mdPath}${notebookFolder}`;
+    paths.resourcePath = `${outputDir}${path.sep}notes${path.sep}${notebookFolder}${path.sep}${yarleOptions.resourcesDir}`;
   }
 
   if (yarleOptions.outputFormat === OutputFormat.LogSeqMD) {
@@ -162,8 +169,6 @@ export const setPaths = (enexSource: string): void => {
     fsExtra.mkdirsSync(paths.resourcePath);
   }
   loggerInfo(`path ${paths.mdPath} created`);
-  // clearDistDir(paths.simpleMdPath);
-  // clearDistDir(paths.complexMdPath);
 };
 
 export const getNotesPath = (): string => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,3 +7,4 @@ export * from './save-html-file';
 export * from './save-md-file';
 export * from './loggerInfo';
 export * from './escape-string-regexp';
+export * from './discover-enex-files';

--- a/src/yarle.ts
+++ b/src/yarle.ts
@@ -218,12 +218,17 @@ export const dropTheRope = async (options: YarleOptions): Promise<Array<string>>
   setOptions(options);
   utils.createRootOutputDir();
   saveOptionsAsConfig(options)
+
+  // Expand directory sources to individual .enex files with relative paths
+  utils.expandEnexSourceDirs(yarleOptions);
+
   const outputNotebookFolders = [];
-  for (const enex of options.enexSources) {
+  for (const enex of yarleOptions.enexSources) {
+    yarleOptions._currentEnexRelativeDir = yarleOptions._enexRelativeDirs?.[enex] || '';
     utils.setPaths(enex);
     const runtimeProps = RuntimePropertiesSingleton.getInstance();
     runtimeProps.setCurrentNotebookName(utils.getNotebookName(enex));
-    await parseStream(options, enex);
+    await parseStream(yarleOptions, enex);
     outputNotebookFolders.push(utils.getNotesPath());
   }
 

--- a/src/yarle.ts
+++ b/src/yarle.ts
@@ -67,6 +67,8 @@ export const defaultYarleOptions: YarleOptions = {
   globalReplacementSettings: [],
   pathSeparator: '/',
   resourcesDir: '_resources',
+  preserveStackFolderStructure: false,
+  preserveStackNamingStructure: false,
   turndownOptions: {
     headingStyle: 'atx',
   },

--- a/test/data/test-nested-stacks-collision/CollisionStack/same-name.enex
+++ b/test/data/test-nested-stacks-collision/CollisionStack/same-name.enex
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export3.dtd">
+<en-export export-date="20181006T084855Z" application="Evernote" version="Evernote Mac 7.5 (457109)">
+<note><title>collision stacked note</title><content><![CDATA[<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div>Stacked same-name</div></en-note>]]></content><created>20181006T084349Z</created><updated>20181006T084411Z</updated><note-attributes><author>test</author><source>desktop.mac</source></note-attributes></note>
+</en-export>

--- a/test/data/test-nested-stacks-collision/same-name.enex
+++ b/test/data/test-nested-stacks-collision/same-name.enex
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export3.dtd">
+<en-export export-date="20181006T084855Z" application="Evernote" version="Evernote Mac 7.5 (457109)">
+<note><title>collision top note</title><content><![CDATA[<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div>Top level same-name</div></en-note>]]></content><created>20181006T084349Z</created><updated>20181006T084411Z</updated><note-attributes><author>test</author><source>desktop.mac</source></note-attributes></note>
+</en-export>

--- a/test/data/test-nested-stacks/MyStack/stacked-notebook.enex
+++ b/test/data/test-nested-stacks/MyStack/stacked-notebook.enex
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export3.dtd">
+<en-export export-date="20181006T084855Z" application="Evernote" version="Evernote Mac 7.5 (457109)">
+<note><title>stacked note</title><content><![CDATA[<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div>Stacked content</div></en-note>]]></content><created>20181006T084349Z</created><updated>20181006T084411Z</updated><note-attributes><author>test</author><source>desktop.mac</source></note-attributes></note>
+</en-export>

--- a/test/data/test-nested-stacks/top-level-notebook.enex
+++ b/test/data/test-nested-stacks/top-level-notebook.enex
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export3.dtd">
+<en-export export-date="20181006T084855Z" application="Evernote" version="Evernote Mac 7.5 (457109)">
+<note><title>top level note</title><content><![CDATA[<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div>Top level content</div></en-note>]]></content><created>20181006T084349Z</created><updated>20181006T084411Z</updated><note-attributes><author>test</author><source>desktop.mac</source></note-attributes></note>
+</en-export>

--- a/test/yarle-tests.ts
+++ b/test/yarle-tests.ts
@@ -879,4 +879,68 @@ export const yarleTests: Array<YarleTest> = [
 
     expectedOutputPath: `${dataFolder}test-note-attributes.md`,
   },
+
+  // --- Recursive stacks tests ---
+  {
+    name: 'Nested stacks - flat mode discovers stacked enex files',
+    options: {
+      enexSources: [ `.${testDataFolder}test-nested-stacks` ],
+      outputDir: 'out',
+      isMetadataNeeded: true,
+    },
+    testOutputPath: `notes${path.sep}stacked-notebook${path.sep}stacked note.md`,
+    expectedOutputPath: undefined,
+  },
+  {
+    name: 'Nested stacks - flat mode discovers top-level enex files',
+    options: {
+      enexSources: [ `.${testDataFolder}test-nested-stacks` ],
+      outputDir: 'out',
+      isMetadataNeeded: true,
+    },
+    testOutputPath: `notes${path.sep}top-level-notebook${path.sep}top level note.md`,
+    expectedOutputPath: undefined,
+  },
+  {
+    name: 'Nested stacks - preserveStackFolderStructure recreates hierarchy',
+    options: {
+      enexSources: [ `.${testDataFolder}test-nested-stacks` ],
+      outputDir: 'out',
+      isMetadataNeeded: true,
+      preserveStackFolderStructure: true,
+    },
+    testOutputPath: `notes${path.sep}MyStack${path.sep}stacked-notebook${path.sep}stacked note.md`,
+    expectedOutputPath: undefined,
+  },
+  {
+    name: 'Nested stacks - preserveStackNamingStructure prefixes folder name',
+    options: {
+      enexSources: [ `.${testDataFolder}test-nested-stacks` ],
+      outputDir: 'out',
+      isMetadataNeeded: true,
+      preserveStackNamingStructure: true,
+    },
+    testOutputPath: `notes${path.sep}MyStack - stacked-notebook${path.sep}stacked note.md`,
+    expectedOutputPath: undefined,
+  },
+  {
+    name: 'Nested stacks - collision auto-promotes stacked file to naming structure',
+    options: {
+      enexSources: [ `.${testDataFolder}test-nested-stacks-collision` ],
+      outputDir: 'out',
+      isMetadataNeeded: true,
+    },
+    testOutputPath: `notes${path.sep}CollisionStack - same-name${path.sep}collision stacked note.md`,
+    expectedOutputPath: undefined,
+  },
+  {
+    name: 'Nested stacks - collision leaves top-level file unaffected',
+    options: {
+      enexSources: [ `.${testDataFolder}test-nested-stacks-collision` ],
+      outputDir: 'out',
+      isMetadataNeeded: true,
+    },
+    testOutputPath: `notes${path.sep}same-name${path.sep}collision top note.md`,
+    expectedOutputPath: undefined,
+  },
 ]


### PR DESCRIPTION
## Summary

- Adds recursive scanning of subdirectories when `enexSources` points to a directory, discovering all `.enex` files in nested folders (Evernote "stacks")
- Adds two new config options: `preserveStackFolderStructure` and `preserveStackNamingStructure` to control how stack hierarchy appears in output
- Detects name collisions in flat mode and auto-enables naming prefixes to prevent data loss

Closes #353, closes #540, closes #678

## Motivation

Evernote exports organize notebooks into "stacks" represented as subdirectories containing `.enex` files. Currently, yarle only reads `.enex` files from the immediate directory — subdirectories are silently ignored. This has been requested in three separate issues spanning 2023-2025.

## Output Modes

| `preserveStackFolderStructure` | `preserveStackNamingStructure` | Output for `Stack/Notebook.enex` |
|---|---|---|
| `false` (default) | `false` (default) | `notes/Notebook/` |
| `true` | n/a | `notes/Stack/Notebook/` |
| `false` | `true` | `notes/Stack - Notebook/` |

If a name collision is detected (e.g., `Notebook.enex` exists at both the top level and inside a stack), `preserveStackNamingStructure` is automatically enabled to prevent data loss.

## Changes

- **`src/utils/discover-enex-files.ts`** (new): Recursive `.enex` discovery utility with collision detection
- **`src/utils/folder-utils.ts`**: `setPaths()` uses stack-relative paths based on config flags
- **`src/yarle.ts`**: Calls `expandEnexSourceDirs()` in `dropTheRope()`, sets per-file relative dir
- **`src/dropTheRopeRunner.ts`**: Simplified — directory expansion now handled by `dropTheRope()`
- **`src/YarleOptions.ts`**: Two new user-facing options + two internal tracking properties
- **`README.md`**: Documents new options and Evernote Stacks section

## Backward Compatibility

- Both flags default to `false` — existing behavior is unchanged for directories without subdirectories
- Recursive scanning is unconditional; config flags only control output path structure
- You might want to consider changing the default values to provide better out-of-the-box behavior (I would suggest both true so if the user sets preserveStackFolderStructure to false it drops through to preserveStackNamingStructure behavior) but at the risk of regression for users with stacks.
- 👉 *These changes have NOT been tested with the Yarle UI!!!*

## Test Plan

- [x] 6 new test cases covering all modes + collision handling (all passing)
- [x] Existing test suite passes with no regressions
- [x] Smoke tested against a real Evernote dump with 75 `.enex` files (57 top-level + 18 in 4 stacks)
- [ ] Verify CI passes

**Note:** 12 pre-existing test failures were observed (unrelated to this change, appear to be Node v24 / mocha v10 compatibility issues).

🤖 Code, documentation, and tests generated by J.J Larrea (@skeptikos) with the assistance of [Claude Code](https://claude.com/claude-code)

Thanks for maintaining yarle — it's been a great tool for my Evernote migration and is especially timely now that using ObsidianML as a Claude memory-base is all the rage.                                               
                                                                                                                                      
 — J.J. Larrea (@skeptikos)