### PR TITLE
Allow character replacement map to apply to tags

### DIFF
--- a/src/utils/content-utils.ts
+++ b/src/utils/content-utils.ts
@@ -174,6 +174,14 @@ export const logTags = (note: EvernoteNoteData): string => {
       let cleanTag = tag
         .toString()
         .replace(/^#/, '');
+
+      if (yarleOptions.replacementCharacterMap) {
+        for (const key of Object.keys(yarleOptions.replacementCharacterMap)) {
+          const replacement = yarleOptions.replacementCharacterMap[key as any];
+          const regex: RegExp = new RegExp(escapeStringRegexp(key), 'g');
+          cleanTag = cleanTag.replace(regex, replacement);
+        }
+      }
         
       cleanTag = performRegexpOnTag(yarleOptions, cleanTag)
       if (tagOptions) {

--- a/test/data/test-tag-char-replacement.enex
+++ b/test/data/test-tag-char-replacement.enex
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export4.dtd">
+<en-export export-date="20240108T103100Z" application="Evernote" version="10.68.3">
+  <note>
+    <title>tag-replace</title>
+    <created>20240108T100000Z</created>
+    <updated>20240108T103000Z</updated>
+    <tag>proj:foo+bar@2026</tag>
+    <content><![CDATA[<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div>Tag replacement test.</div></en-note>]]></content>
+  </note>
+</en-export>

--- a/test/data/test-tag-char-replacement.md
+++ b/test/data/test-tag-char-replacement.md
@@ -1,0 +1,12 @@
+# tag-replace
+
+---
+Tag(s): #proj/foo-plus-bar-at-2026
+
+---
+
+Tag replacement test.
+
+    Created at: 2024-01-08T10:00:00+00:00
+    Updated at: 2024-01-08T10:30:00+00:00
+

--- a/test/yarle-special-cases.spec.ts
+++ b/test/yarle-special-cases.spec.ts
@@ -138,6 +138,37 @@ dateFormat: undefined,
     );
   });
 
+  it('Apply replacementCharacterMap to tags', async () => {
+    const options: YarleOptions = {
+dateFormat: undefined,
+      enexSources: [ `.${path.sep}test${path.sep}data${path.sep}test-tag-char-replacement.enex` ],
+      outputDir: 'out',
+      outputFormat: OutputFormat.ObsidianMD,
+      isMetadataNeeded: true,
+      replacementCharacterMap: {
+        ":": "/",
+        "+": "-plus-",
+        "@": "-at-"
+      },
+      removeUnicodeCharsFromTags: false,
+    };
+    await yarle.dropTheRope(options);
+    assert.equal(
+      fs.existsSync(
+        `${__dirname}/../out/notes/test-tag-char-replacement/tag-replace.md`,
+      ),
+      true,
+    );
+
+    assert.equal(
+      eol.auto(fs.readFileSync(
+        `${__dirname}/../out/notes/test-tag-char-replacement/tag-replace.md`,
+        'utf8',
+      )),
+      fs.readFileSync(`${__dirname}/data/test-tag-char-replacement.md`, 'utf8'),
+    );
+  });
+
   it('Replace newlines', async () => {
     const options: YarleOptions = {
 dateFormat: undefined,


### PR DESCRIPTION
## Summary
- apply eplacementCharacterMap replacements to tags during tag processing
- keep existing tag processing flow (regex replacement, nested tags, whitespace replacement) intact
- add regression coverage with a new fixture and spec for tag character replacement

## Why
Fixes #536 by allowing Evernote tag characters to be transformed via a simple mapping, similar to filename/resource replacement.

## Verification
- 
pm run build (passes)
- Full test suite could not be executed in this Windows/Node 24 environment due existing mocha/ts-node module-loading incompatibility in this repo setup.

Fixes #536