### PR TITLE
Add browser ENEX to Markdown prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ Just open a terminal, specify config options in a config file (options detailed 
 npx -p yarle-evernote-to-md@latest yarle --configFile <path_to_your_file e.g. ./config.json>
 ```
 
+## Browser web prototype
+
+YARLE also includes an experimental browser-only converter in `src/web`.
+It reads `.enex` files locally with the browser File API and converts text
+notes to Markdown without uploading your notes to a server.
+
+Run it locally from the repository root:
+
+```sh
+python3 -m http.server 8080 --directory src/web
+```
+
+Then open `http://localhost:8080`. See [WEB_APP.md](WEB_APP.md) for the
+current scope and limitations.
+
 ## Yarle intro and usage videos on Youtube:
 <a href="https://www.youtube.com/watch?v=EPMkm5zRIts">How to migrate notes from Evernote to Obsidian (using Yarle)</a><br>
 <a href="https://www.youtube.com/watch?v=gZxMz67uYHg">YARLE: A lifeline to escape from Evernote</a>

--- a/WEB_APP.md
+++ b/WEB_APP.md
@@ -1,0 +1,36 @@
+# YARLE Web Converter Prototype
+
+This directory contains a browser-only prototype for converting Evernote ENEX
+exports to Markdown without uploading notes to a server.
+
+## Run locally
+
+From the repository root:
+
+```sh
+python3 -m http.server 8080 --directory src/web
+```
+
+Open `http://localhost:8080`, select one or more `.enex` files, and click
+**Convert**.
+
+## Current scope
+
+- Reads ENEX files with the browser `File` API.
+- Parses notes, titles, created/updated dates, tags, and source URLs.
+- Converts common ENML/HTML tags to Markdown.
+- Supports Standard Markdown and Obsidian-friendly attachment placeholders.
+- Copies combined Markdown, downloads Markdown files, or saves to a directory
+  when the browser supports the File System Access API.
+
+## Limitations
+
+This is an initial web MVP and does not yet match the CLI/Electron converter:
+
+- Attachments are emitted as Markdown placeholders instead of being extracted.
+- Advanced YARLE templates are not implemented.
+- Task output formats and application-specific dialects are limited.
+- Very large ENEX exports may need streaming parsing in a future iteration.
+
+Use the desktop app or CLI for full-fidelity exports until the web converter
+reaches feature parity.

--- a/src/web/app.js
+++ b/src/web/app.js
@@ -1,0 +1,373 @@
+(function () {
+  const state = {
+    files: [],
+    convertedNotes: [],
+  };
+
+  const enexFiles = document.getElementById('enexFiles');
+  const fileList = document.getElementById('fileList');
+  const convertButton = document.getElementById('convertButton');
+  const copyButton = document.getElementById('copyButton');
+  const downloadButton = document.getElementById('downloadButton');
+  const saveDirectoryButton = document.getElementById('saveDirectoryButton');
+  const logOutput = document.getElementById('logOutput');
+  const preview = document.getElementById('preview');
+  const targetDialect = document.getElementById('targetDialect');
+  const metadataMode = document.getElementById('metadataMode');
+  const skipWebClips = document.getElementById('skipWebClips');
+  const includeTags = document.getElementById('includeTags');
+
+  enexFiles.addEventListener('change', () => {
+    state.files = Array.from(enexFiles.files || []);
+    renderFiles();
+    log(state.files.length ? 'Ready to convert.' : 'Waiting for files...');
+  });
+
+  convertButton.addEventListener('click', async () => {
+    if (!state.files.length) {
+      log('Select at least one ENEX file first.');
+      return;
+    }
+
+    setBusy(true);
+    state.convertedNotes = [];
+    const messages = [];
+
+    for (const file of state.files) {
+      try {
+        const text = await file.text();
+        const result = convertEnex(text, {
+          fileName: file.name,
+          dialect: targetDialect.value,
+          metadataMode: metadataMode.value,
+          skipWebClips: skipWebClips.checked,
+          includeTags: includeTags.checked,
+        });
+        state.convertedNotes.push(...result.notes);
+        messages.push(`${file.name}: ${result.notes.length} converted, ${result.skipped} skipped`);
+      } catch (error) {
+        messages.push(`${file.name}: failed - ${error.message}`);
+      }
+    }
+
+    setBusy(false);
+    updateActionState();
+    renderPreview();
+    log(messages.join('\n'));
+  });
+
+  copyButton.addEventListener('click', async () => {
+    const markdown = state.convertedNotes.map((note) => note.markdown).join('\n\n---\n\n');
+    await navigator.clipboard.writeText(markdown);
+    log(`Copied ${state.convertedNotes.length} note(s) to the clipboard.`);
+  });
+
+  downloadButton.addEventListener('click', () => {
+    for (const note of state.convertedNotes) {
+      downloadText(note.fileName, note.markdown);
+    }
+    log(`Started ${state.convertedNotes.length} Markdown download(s).`);
+  });
+
+  saveDirectoryButton.addEventListener('click', async () => {
+    if (!('showDirectoryPicker' in window)) {
+      log('Directory saving is not available in this browser. Use downloads instead.');
+      return;
+    }
+
+    const directory = await window.showDirectoryPicker({ mode: 'readwrite' });
+    for (const note of state.convertedNotes) {
+      const handle = await directory.getFileHandle(note.fileName, { create: true });
+      const writable = await handle.createWritable();
+      await writable.write(note.markdown);
+      await writable.close();
+    }
+    log(`Saved ${state.convertedNotes.length} note(s) to the selected directory.`);
+  });
+
+  function convertEnex(source, options) {
+    const xmlText = source.replace(/<!DOCTYPE[\s\S]*?>/g, '');
+    const parser = new DOMParser();
+    const documentXml = parser.parseFromString(xmlText, 'application/xml');
+    const parserError = documentXml.querySelector('parsererror');
+
+    if (parserError) {
+      throw new Error(parserError.textContent.trim().replace(/\s+/g, ' '));
+    }
+
+    const notes = [];
+    let skipped = 0;
+
+    for (const noteNode of Array.from(documentXml.querySelectorAll('note'))) {
+      const isWebClip = getText(noteNode, 'content-class').includes('evernote.webclip');
+      if (options.skipWebClips && isWebClip) {
+        skipped += 1;
+        continue;
+      }
+
+      const title = getText(noteNode, 'title') || 'Untitled';
+      const content = getText(noteNode, 'content');
+      const tags = Array.from(noteNode.querySelectorAll('tag')).map((tag) => tag.textContent.trim()).filter(Boolean);
+      const metadata = {
+        title,
+        created: formatEvernoteDate(getText(noteNode, 'created')),
+        updated: formatEvernoteDate(getText(noteNode, 'updated')),
+        sourceUrl: getText(noteNode, 'source-url'),
+        tags,
+      };
+      const markdownBody = htmlToMarkdown(content, options);
+      const markdown = buildMarkdown(metadata, markdownBody, options);
+      notes.push({
+        title,
+        fileName: `${sanitizeFileName(title)}.md`,
+        markdown,
+      });
+    }
+
+    return { notes, skipped };
+  }
+
+  function buildMarkdown(metadata, markdownBody, options) {
+    if (options.metadataMode === 'none') {
+      return `# ${metadata.title}\n\n${markdownBody}`.trim();
+    }
+
+    const frontMatter = [
+      '---',
+      `title: "${escapeYaml(metadata.title)}"`,
+      metadata.created ? `created: ${metadata.created}` : '',
+      metadata.updated ? `updated: ${metadata.updated}` : '',
+      metadata.sourceUrl ? `source: "${escapeYaml(metadata.sourceUrl)}"` : '',
+      options.includeTags && metadata.tags.length ? `tags: [${metadata.tags.map((tag) => `"${escapeYaml(tag)}"`).join(', ')}]` : '',
+      '---',
+    ].filter(Boolean).join('\n');
+
+    return `${frontMatter}\n\n# ${metadata.title}\n\n${markdownBody}`.trim();
+  }
+
+  function htmlToMarkdown(enmlContent, options) {
+    if (!enmlContent.trim()) {
+      return '';
+    }
+
+    const htmlText = enmlContent
+      .replace(/<!DOCTYPE[\s\S]*?>/g, '')
+      .replace(/<en-note/g, '<section')
+      .replace(/<\/en-note>/g, '</section>');
+    const htmlDocument = new DOMParser().parseFromString(htmlText, 'text/html');
+    const root = htmlDocument.body;
+    const markdown = renderChildren(root, options)
+      .replace(/[ \t]+\n/g, '\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim();
+
+    return markdown || root.textContent.trim();
+  }
+
+  function renderChildren(node, options) {
+    return Array.from(node.childNodes).map((child) => renderNode(child, options)).join('');
+  }
+
+  function renderNode(node, options) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      return node.textContent.replace(/\s+/g, ' ');
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return '';
+    }
+
+    const tag = node.tagName.toLowerCase();
+    const inner = renderChildren(node, options).trim();
+
+    switch (tag) {
+      case 'section':
+      case 'article':
+      case 'main':
+      case 'body':
+        return `${inner}\n\n`;
+      case 'div':
+      case 'p':
+        return inner ? `${inner}\n\n` : '\n';
+      case 'br':
+        return '\n';
+      case 'h1':
+      case 'h2':
+      case 'h3':
+      case 'h4':
+      case 'h5':
+      case 'h6':
+        return `${'#'.repeat(Number(tag.slice(1)))} ${inner}\n\n`;
+      case 'strong':
+      case 'b':
+        return inner ? `**${inner}**` : '';
+      case 'em':
+      case 'i':
+        return inner ? `_${inner}_` : '';
+      case 's':
+      case 'strike':
+      case 'del':
+        return inner ? `~~${inner}~~` : '';
+      case 'code':
+        return inner ? `\`${inner.replace(/`/g, '\\`')}\`` : '';
+      case 'pre':
+        return `\n\`\`\`\n${node.textContent.trim()}\n\`\`\`\n\n`;
+      case 'blockquote':
+        return `${inner.split('\n').map((line) => `> ${line}`).join('\n')}\n\n`;
+      case 'ul':
+        return `${renderList(node, false, options)}\n`;
+      case 'ol':
+        return `${renderList(node, true, options)}\n`;
+      case 'li':
+        return inner;
+      case 'a': {
+        const href = node.getAttribute('href');
+        return href ? `[${inner || href}](${href})` : inner;
+      }
+      case 'img':
+      case 'en-media': {
+        const title = node.getAttribute('title') || node.getAttribute('alt') || node.getAttribute('hash') || 'attachment';
+        return options.dialect === 'obsidian'
+          ? `![[${title}]]`
+          : `![${title}](${title})`;
+      }
+      case 'table':
+        return `${renderTable(node, options)}\n\n`;
+      default:
+        return inner;
+    }
+  }
+
+  function renderList(node, ordered, options) {
+    return Array.from(node.children)
+      .filter((child) => child.tagName.toLowerCase() === 'li')
+      .map((item, index) => {
+        const marker = ordered ? `${index + 1}.` : '-';
+        const content = renderChildren(item, options).trim().replace(/\n/g, '\n  ');
+        return `${marker} ${content}`;
+      })
+      .join('\n');
+  }
+
+  function renderTable(node, options) {
+    const rows = Array.from(node.querySelectorAll('tr')).map((row) =>
+      Array.from(row.children).map((cell) => renderChildren(cell, options).trim().replace(/\|/g, '\\|'))
+    );
+
+    if (!rows.length) {
+      return '';
+    }
+
+    const width = Math.max(...rows.map((row) => row.length));
+    const normalizedRows = rows.map((row) => Array.from({ length: width }, (_, index) => row[index] || ''));
+    const header = normalizedRows[0];
+    const separator = Array.from({ length: width }, () => '---');
+    const body = normalizedRows.slice(1);
+
+    return [header, separator, ...body]
+      .map((row) => `| ${row.join(' | ')} |`)
+      .join('\n');
+  }
+
+  function getText(node, selector) {
+    const found = node.querySelector(selector);
+    return found && found.textContent ? found.textContent.trim() : '';
+  }
+
+  function formatEvernoteDate(value) {
+    const match = value.match(/^(\d{4})(\d{2})(\d{2})T?(\d{2})?(\d{2})?(\d{2})?Z?$/);
+    if (!match) {
+      return '';
+    }
+    const [, year, month, day, hour = '00', minute = '00', second = '00'] = match;
+    return `${year}-${month}-${day}T${hour}:${minute}:${second}Z`;
+  }
+
+  function sanitizeFileName(value) {
+    const sanitized = value
+      .replace(/[<>:"/\\|?*\u0000-\u001F]/g, '_')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 120);
+    return sanitized || 'Untitled';
+  }
+
+  function escapeYaml(value) {
+    return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  }
+
+  function downloadText(fileName, text) {
+    const blob = new Blob([text], { type: 'text/markdown;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function renderFiles() {
+    if (!state.files.length) {
+      fileList.textContent = 'No files selected.';
+      return;
+    }
+
+    fileList.innerHTML = state.files.map((file) => `
+      <div class="file-row">
+        <span>${escapeHtml(file.name)}</span>
+        <span>${formatBytes(file.size)}</span>
+      </div>
+    `).join('');
+  }
+
+  function renderPreview() {
+    if (!state.convertedNotes.length) {
+      preview.className = 'preview empty';
+      preview.textContent = 'No notes converted.';
+      return;
+    }
+
+    preview.className = 'preview';
+    preview.innerHTML = state.convertedNotes.slice(0, 10).map((note) => `
+      <article class="note-card">
+        <h3>${escapeHtml(note.title)}</h3>
+        <p>${escapeHtml(note.markdown.slice(0, 240))}${note.markdown.length > 240 ? '...' : ''}</p>
+      </article>
+    `).join('');
+  }
+
+  function updateActionState() {
+    const hasOutput = state.convertedNotes.length > 0;
+    copyButton.disabled = !hasOutput;
+    downloadButton.disabled = !hasOutput;
+    saveDirectoryButton.disabled = !hasOutput || !('showDirectoryPicker' in window);
+  }
+
+  function setBusy(isBusy) {
+    convertButton.disabled = isBusy;
+    convertButton.textContent = isBusy ? 'Converting...' : 'Convert';
+  }
+
+  function log(message) {
+    logOutput.textContent = message;
+  }
+
+  function escapeHtml(value) {
+    const div = document.createElement('div');
+    div.textContent = value;
+    return div.innerHTML;
+  }
+
+  function formatBytes(value) {
+    if (value < 1024) {
+      return `${value} B`;
+    }
+    if (value < 1024 * 1024) {
+      return `${(value / 1024).toFixed(1)} KB`;
+    }
+    return `${(value / 1024 / 1024).toFixed(1)} MB`;
+  }
+
+  renderFiles();
+  updateActionState();
+})();

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>YARLE Web Converter</title>
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body>
+    <main class="shell">
+      <section class="hero">
+        <div>
+          <p class="eyebrow">Browser prototype</p>
+          <h1>YARLE Web Converter</h1>
+          <p class="lede">
+            Convert Evernote ENEX exports to Markdown in your browser. Files stay local;
+            the page does not upload notes to a server.
+          </p>
+        </div>
+        <div class="privacy-note">
+          <strong>Local only</strong>
+          <span>Runs with File, Blob, and optional File System Access APIs.</span>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <div>
+            <h2>Select ENEX files</h2>
+            <p>Choose one or more exported Evernote notebooks.</p>
+          </div>
+          <label class="file-picker">
+            <input id="enexFiles" type="file" accept=".enex,.xml,text/xml,application/xml" multiple>
+            <span>Choose files</span>
+          </label>
+        </div>
+
+        <div id="fileList" class="file-list" aria-live="polite"></div>
+
+        <div class="options-grid">
+          <label>
+            Target dialect
+            <select id="targetDialect">
+              <option value="standard">Standard Markdown</option>
+              <option value="obsidian">Obsidian friendly</option>
+            </select>
+          </label>
+          <label>
+            Metadata
+            <select id="metadataMode">
+              <option value="frontmatter">YAML front matter</option>
+              <option value="none">No metadata</option>
+            </select>
+          </label>
+          <label class="checkbox">
+            <input id="skipWebClips" type="checkbox" checked>
+            <span>Skip web clips</span>
+          </label>
+          <label class="checkbox">
+            <input id="includeTags" type="checkbox" checked>
+            <span>Include tags</span>
+          </label>
+        </div>
+
+        <div class="actions">
+          <button id="convertButton" type="button">Convert</button>
+          <button id="copyButton" type="button" disabled>Copy combined Markdown</button>
+          <button id="downloadButton" type="button" disabled>Download Markdown files</button>
+          <button id="saveDirectoryButton" type="button" disabled>Save to directory</button>
+        </div>
+      </section>
+
+      <section class="split">
+        <div class="panel">
+          <h2>Conversion log</h2>
+          <pre id="logOutput" class="log-output">Waiting for files...</pre>
+        </div>
+        <div class="panel">
+          <h2>Preview</h2>
+          <div id="preview" class="preview empty">Converted notes will appear here.</div>
+        </div>
+      </section>
+
+      <section class="panel limitations">
+        <h2>Prototype scope</h2>
+        <ul>
+          <li>Supports text notes, common ENML tags, tags, created/updated dates, and source URLs.</li>
+          <li>Attachments are listed as placeholders because browsers cannot reconstruct Evernote resources without additional export handling.</li>
+          <li>Use the desktop or CLI app for full-fidelity conversion until the browser converter reaches parity.</li>
+        </ul>
+      </section>
+    </main>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/src/web/styles.css
+++ b/src/web/styles.css
@@ -1,0 +1,276 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f1ea;
+  --panel: #fffaf3;
+  --ink: #231f20;
+  --muted: #6e6257;
+  --line: #ddd0c2;
+  --accent: #d35f2d;
+  --accent-strong: #9f3f1e;
+  --success: #176f4a;
+  --shadow: 0 20px 60px rgba(72, 43, 21, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+.shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 36px 0;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 260px;
+  gap: 24px;
+  align-items: end;
+  margin-bottom: 24px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent-strong);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+  line-height: 1.08;
+}
+
+h1 {
+  font-size: clamp(2rem, 4vw, 4rem);
+}
+
+h2 {
+  font-size: 1.1rem;
+}
+
+.lede {
+  max-width: 720px;
+  margin: 14px 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.55;
+}
+
+.privacy-note {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 16px;
+  background: rgba(255, 250, 243, 0.72);
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+}
+
+.privacy-note strong {
+  color: var(--success);
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  padding: 22px;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.panel-header p {
+  margin: 6px 0 0;
+  color: var(--muted);
+}
+
+.file-picker input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+
+.file-picker span,
+button {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #fff;
+  padding: 0 16px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  background: #c5b7aa;
+}
+
+button:not(:disabled):hover,
+.file-picker span:hover {
+  background: var(--accent-strong);
+}
+
+.file-list {
+  display: grid;
+  gap: 8px;
+  min-height: 28px;
+  margin: 18px 0;
+  color: var(--muted);
+}
+
+.file-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 8px;
+}
+
+.options-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+label {
+  display: grid;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+select {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--ink);
+  padding: 10px;
+}
+
+.checkbox {
+  align-content: end;
+  grid-template-columns: 18px 1fr;
+  gap: 10px;
+  color: var(--ink);
+}
+
+.checkbox input {
+  width: 18px;
+  height: 18px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 24px;
+  margin-top: 24px;
+}
+
+.log-output,
+.preview {
+  min-height: 320px;
+  max-height: 480px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fff;
+  padding: 14px;
+}
+
+.log-output {
+  white-space: pre-wrap;
+  color: #3a332c;
+}
+
+.preview {
+  display: grid;
+  gap: 14px;
+}
+
+.preview.empty {
+  color: var(--muted);
+  align-content: start;
+}
+
+.note-card {
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 14px;
+}
+
+.note-card:last-child {
+  border-bottom: 0;
+}
+
+.note-card h3 {
+  margin: 0 0 8px;
+}
+
+.note-card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.limitations {
+  margin-top: 24px;
+}
+
+.limitations ul {
+  margin: 12px 0 0;
+  padding-left: 20px;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+@media (max-width: 820px) {
+  .hero,
+  .split,
+  .options-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary

Hi, I opened this PR to address the web app request in #470 with an initial browser-only ENEX to Markdown prototype.

The change adds:

- `src/web/index.html`, `styles.css`, and `app.js` for a static browser converter.
- Local `.enex` file selection through the browser File API.
- Basic ENEX parsing and ENML/HTML to Markdown conversion.
- Copy, download, and optional File System Access API directory saving.
- `WEB_APP.md` documentation covering scope and current limitations.
- A README section that explains how to run the web prototype locally.

This is intentionally scoped as an MVP and does not yet replace the full CLI/Electron converter. Attachments are emitted as placeholders, and advanced templates/task dialect behavior remains future work.

## Verification

- `node --check src/web/app.js`
- `git diff --check --cached`
- Served locally with `python3 -m http.server 8091 --bind 127.0.0.1 --directory src/web`
- Confirmed `GET /` returned `200` from `http://127.0.0.1:8091/`

This contribution was prepared with AI assistance and manually checked through the available local checks.

